### PR TITLE
Create Next.js login with registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="file:./dev.db"
+NEXTAUTH_SECRET="your-secret"

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined }
+
+export const prisma =
+  globalForPrisma.prisma || new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sdn-app",
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "prisma": "prisma"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-auth": "4.22.1",
+    "@prisma/client": "5.1.1",
+    "bcryptjs": "2.4.3"
+  },
+  "devDependencies": {
+    "prisma": "5.1.1",
+    "typescript": "5.2.2"
+  }
+}

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,38 @@
+import NextAuth from 'next-auth'
+import CredentialsProvider from 'next-auth/providers/credentials'
+import { prisma } from '../../../lib/prisma'
+import { compare } from 'bcryptjs'
+
+export default NextAuth({
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'text' },
+        password: { label: 'Password', type: 'password' }
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) {
+          throw new Error('Missing credentials')
+        }
+        const user = await prisma.user.findUnique({
+          where: { email: credentials.email }
+        })
+        if (!user) {
+          throw new Error('No user found')
+        }
+        const isValid = await compare(credentials.password, user.password)
+        if (!isValid) {
+          throw new Error('Invalid password')
+        }
+        return { id: user.id, name: user.name, email: user.email }
+      }
+    })
+  ],
+  session: {
+    strategy: 'jwt'
+  },
+  pages: {
+    signIn: '/login'
+  }
+})

--- a/pages/api/register.ts
+++ b/pages/api/register.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../lib/prisma'
+import { hash } from 'bcryptjs'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  const { name, email, password } = req.body
+  if (!name || !email || !password) {
+    return res.status(400).json({ message: 'Missing fields' })
+  }
+
+  const existing = await prisma.user.findUnique({ where: { email } })
+  if (existing) {
+    return res.status(400).json({ message: 'User already exists' })
+  }
+
+  const hashed = await hash(password, 10)
+  const user = await prisma.user.create({
+    data: { name, email, password: hashed }
+  })
+
+  return res.status(200).json({ id: user.id, email: user.email })
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,35 @@
+import { getSession } from 'next-auth/react'
+import { GetServerSideProps } from 'next'
+
+export default function Dashboard() {
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh' }}>
+      <aside style={{ width: '200px', background: '#333', color: '#fff', padding: '1rem' }}>
+        <h2>Sidebar</h2>
+        <ul>
+          <li>Enlace 1</li>
+          <li>Enlace 2</li>
+        </ul>
+      </aside>
+      <main style={{ flex: 1, padding: '1rem' }}>
+        <h1>Dashboard</h1>
+        <p>Contenido privado</p>
+      </main>
+    </div>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context)
+  if (!session) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false
+      }
+    }
+  }
+  return {
+    props: {}
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,15 @@
+import { useSession } from 'next-auth/react'
+
+export default function Home() {
+  const { data } = useSession()
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Bienvenido</h1>
+      {data ? (
+        <a href='/dashboard'>Ir al dashboard</a>
+      ) : (
+        <a href='/login'>Iniciar sesión</a>
+      )}
+    </div>
+  )
+}

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,51 @@
+import { getCsrfToken } from 'next-auth/react'
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Login({ csrfToken }: { csrfToken: string }) {
+  const router = useRouter()
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const form = e.currentTarget
+    const res = await fetch('/api/auth/callback/credentials', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams(new FormData(form) as any).toString()
+    })
+    if (res.ok) {
+      router.push('/dashboard')
+    } else {
+      setError('Credenciales inválidas')
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', background: '#f5f5f5' }}>
+      <form onSubmit={handleSubmit} style={{ background: 'white', padding: '2rem', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)' }}>
+        <input name='csrfToken' type='hidden' defaultValue={csrfToken} />
+        <h1 style={{ marginBottom: '1rem', textAlign: 'center' }}>Iniciar Sesión</h1>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+        <div style={{ marginBottom: '1rem' }}>
+          <label>Correo</label>
+          <input type='email' name='email' required style={{ width: '100%' }} />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <label>Contraseña</label>
+          <input type='password' name='password' required style={{ width: '100%' }} />
+        </div>
+        <button type='submit' style={{ width: '100%' }}>Entrar</button>
+        <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+          ¿No tienes cuenta? <a href='/register'>Regístrate</a>
+        </p>
+      </form>
+    </div>
+  )
+}
+
+Login.getInitialProps = async (context: any) => {
+  return {
+    csrfToken: await getCsrfToken(context)
+  }
+}

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+
+export default function Register() {
+  const router = useRouter()
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: formData.get('name'),
+        email: formData.get('email'),
+        password: formData.get('password')
+      })
+    })
+    if (res.ok) {
+      router.push('/login')
+    } else {
+      const data = await res.json()
+      setError(data.message || 'Error')
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', background: '#f5f5f5' }}>
+      <form onSubmit={handleSubmit} style={{ background: 'white', padding: '2rem', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)' }}>
+        <h1 style={{ marginBottom: '1rem', textAlign: 'center' }}>Registro</h1>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
+        <div style={{ marginBottom: '1rem' }}>
+          <label>Nombre</label>
+          <input type='text' name='name' required style={{ width: '100%' }} />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <label>Correo</label>
+          <input type='email' name='email' required style={{ width: '100%' }} />
+        </div>
+        <div style={{ marginBottom: '1rem' }}>
+          <label>Contraseña</label>
+          <input type='password' name='password' required style={{ width: '100%' }} />
+        </div>
+        <button type='submit' style={{ width: '100%' }}>Registrar</button>
+        <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+          ¿Ya tienes cuenta? <a href='/login'>Inicia sesión</a>
+        </p>
+      </form>
+    </div>
+  )
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,16 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id       Int      @id @default(autoincrement())
+  name     String
+  email    String   @unique
+  password String
+  createdAt DateTime @default(now())
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize a Next.js app skeleton
- configure Prisma ORM with a simple User model
- add NextAuth credentials provider
- implement login, registration and dashboard pages

## Testing
- `npm install` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686827ef11088322b9464d2eacf127fd