### PR TITLE
Implement JWT auth with prettier forms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-DATABASE_URL="file:./dev.db"
+DATABASE_URL="mysql://USER:PASSWORD@localhost:3306/mydb"
 NEXTAUTH_SECRET="your-secret"

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,4 +1,4 @@
-import { getSession } from 'next-auth/react'
+import { getSession, signOut } from 'next-auth/react'
 import { GetServerSideProps } from 'next'
 
 export default function Dashboard() {
@@ -14,6 +14,9 @@ export default function Dashboard() {
       <main style={{ flex: 1, padding: '1rem' }}>
         <h1>Dashboard</h1>
         <p>Contenido privado</p>
+        <button onClick={() => signOut()} style={{ marginTop: '1rem' }}>
+          Cerrar sesión
+        </button>
       </main>
     </div>
   )

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,6 +1,7 @@
 import { getCsrfToken, signIn } from 'next-auth/react'
 import { useState } from 'react'
 import { useRouter } from 'next/router'
+import styles from '../styles/AuthForm.module.css'
 
 export default function Login({ csrfToken }: { csrfToken: string }) {
   const router = useRouter()
@@ -24,21 +25,21 @@ export default function Login({ csrfToken }: { csrfToken: string }) {
   }
 
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', background: '#f5f5f5' }}>
-      <form onSubmit={handleSubmit} style={{ background: 'white', padding: '2rem', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)' }}>
+    <div className={styles.container}>
+      <form onSubmit={handleSubmit} className={styles.form}>
         <input name='csrfToken' type='hidden' defaultValue={csrfToken} />
         <h1 style={{ marginBottom: '1rem', textAlign: 'center' }}>Iniciar Sesión</h1>
         {error && <p style={{ color: 'red' }}>{error}</p>}
-        <div style={{ marginBottom: '1rem' }}>
+        <div className={styles.field}>
           <label>Correo</label>
-          <input type='email' name='email' required style={{ width: '100%' }} />
+          <input type='email' name='email' required />
         </div>
-        <div style={{ marginBottom: '1rem' }}>
+        <div className={styles.field}>
           <label>Contraseña</label>
-          <input type='password' name='password' required style={{ width: '100%' }} />
+          <input type='password' name='password' required />
         </div>
-        <button type='submit' style={{ width: '100%' }}>Entrar</button>
-        <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+        <button type='submit' className={styles.submit}>Entrar</button>
+        <p className={styles.link}>
           ¿No tienes cuenta? <a href='/register'>Regístrate</a>
         </p>
       </form>

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
+import styles from '../styles/AuthForm.module.css'
 
 export default function Register() {
   const router = useRouter()
@@ -26,24 +27,24 @@ export default function Register() {
   }
 
   return (
-    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', background: '#f5f5f5' }}>
-      <form onSubmit={handleSubmit} style={{ background: 'white', padding: '2rem', borderRadius: '8px', boxShadow: '0 2px 8px rgba(0,0,0,0.1)' }}>
+    <div className={styles.container}>
+      <form onSubmit={handleSubmit} className={styles.form}>
         <h1 style={{ marginBottom: '1rem', textAlign: 'center' }}>Registro</h1>
         {error && <p style={{ color: 'red' }}>{error}</p>}
-        <div style={{ marginBottom: '1rem' }}>
+        <div className={styles.field}>
           <label>Nombre</label>
-          <input type='text' name='name' required style={{ width: '100%' }} />
+          <input type='text' name='name' required />
         </div>
-        <div style={{ marginBottom: '1rem' }}>
+        <div className={styles.field}>
           <label>Correo</label>
-          <input type='email' name='email' required style={{ width: '100%' }} />
+          <input type='email' name='email' required />
         </div>
-        <div style={{ marginBottom: '1rem' }}>
+        <div className={styles.field}>
           <label>Contraseña</label>
-          <input type='password' name='password' required style={{ width: '100%' }} />
+          <input type='password' name='password' required />
         </div>
-        <button type='submit' style={{ width: '100%' }}>Registrar</button>
-        <p style={{ marginTop: '1rem', textAlign: 'center' }}>
+        <button type='submit' className={styles.submit}>Registrar</button>
+        <p className={styles.link}>
           ¿Ya tienes cuenta? <a href='/login'>Inicia sesión</a>
         </p>
       </form>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,5 @@
 datasource db {
-  provider = "sqlite"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 

--- a/styles/AuthForm.module.css
+++ b/styles/AuthForm.module.css
@@ -1,0 +1,37 @@
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #020024 0%, #090979 35%, #00d4ff 100%);
+}
+
+.form {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.field {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.submit {
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background-color: #090979;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.link {
+  text-align: center;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- use MySQL in Prisma schema
- update env example for MySQL
- add simple CSS module to improve login and register forms
- update login, register and dashboard pages to use the new styles and add logout button

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868347bd514832298cb3cddf85dbd88