### PR TITLE
Fix Date serialization in inventory pages

### DIFF
--- a/pages/inventory/[id].tsx
+++ b/pages/inventory/[id].tsx
@@ -102,7 +102,14 @@ export const getServerSideProps: GetServerSideProps = async ({ params, ...contex
 
   const id = Number(params?.id)
   const device = await prisma.device.findUnique({ where: { id } })
+  if (!device) {
+    return { notFound: true }
+  }
+  const serializedDevice = {
+    ...device,
+    createdAt: device.createdAt.toISOString()
+  }
   return {
-    props: { device }
+    props: { device: serializedDevice }
   }
 }

--- a/pages/inventory/index.tsx
+++ b/pages/inventory/index.tsx
@@ -189,7 +189,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
 
   const devices = await prisma.device.findMany()
+  const serializedDevices = devices.map((d) => ({
+    ...d,
+    createdAt: d.createdAt.toISOString()
+  }))
   return {
-    props: { devices }
+    props: { devices: serializedDevices }
   }
 }


### PR DESCRIPTION
## Summary
- convert `createdAt` field to ISO strings before returning from `getServerSideProps`
- handle missing record in inventory item page

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68683cbdee7c8322a994aa684eaa1808