### PR TITLE
Add sites and brands management with UI updates

### DIFF
--- a/components/SidebarLayout.tsx
+++ b/components/SidebarLayout.tsx
@@ -1,16 +1,12 @@
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import NextLink from 'next/link'
-import { Box, Flex, Button, VStack, Text } from '@chakra-ui/react'
+import { Box, Flex, Button, VStack, Text, Collapse } from '@chakra-ui/react'
 
 export default function SidebarLayout({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false)
   return (
     <Flex minH='100vh'>
-      <Box
-        w='200px'
-        bgGradient='linear(to-b, #020024, #090979, #00d4ff)'
-        color='white'
-        p={4}
-      >
+      <Box w='220px' bg='gray.800' color='white' p={4}>
         <Text fontSize='lg' fontWeight='bold' mb={4}>
           Menu
         </Text>
@@ -26,15 +22,51 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
             Dashboard
           </Button>
           <Button
-            as={NextLink}
-            href='/inventory'
             bg='white'
             color='gray.800'
             _hover={{ bg: 'gray.200' }}
             w='100%'
+            onClick={() => setOpen(!open)}
           >
-            Inventario
+            Dispositivos
           </Button>
+          <Collapse in={open} animateOpacity>
+            <VStack align='stretch' spacing={1} mt={1} pl={2}>
+              <Button
+                as={NextLink}
+                href='/inventory'
+                bg='white'
+                color='gray.800'
+                _hover={{ bg: 'gray.200' }}
+                w='100%'
+                size='sm'
+              >
+                Inventario
+              </Button>
+              <Button
+                as={NextLink}
+                href='/sites'
+                bg='white'
+                color='gray.800'
+                _hover={{ bg: 'gray.200' }}
+                w='100%'
+                size='sm'
+              >
+                Sitios
+              </Button>
+              <Button
+                as={NextLink}
+                href='/brands'
+                bg='white'
+                color='gray.800'
+                _hover={{ bg: 'gray.200' }}
+                w='100%'
+                size='sm'
+              >
+                Marcas
+              </Button>
+            </VStack>
+          </Collapse>
         </VStack>
       </Box>
       <Box flex='1' p={4} bg='gray.50'>

--- a/pages/api/brands/[id].ts
+++ b/pages/api/brands/[id].ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+
+  if (req.method === 'GET') {
+    const brand = await prisma.brand.findUnique({ where: { id } })
+    return res.status(200).json(brand)
+  }
+
+  if (req.method === 'PUT') {
+    const data = req.body
+    const brand = await prisma.brand.update({ where: { id }, data })
+    return res.status(200).json(brand)
+  }
+
+  if (req.method === 'DELETE') {
+    await prisma.brand.delete({ where: { id } })
+    return res.status(204).end()
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/brands/index.ts
+++ b/pages/api/brands/index.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const brands = await prisma.brand.findMany()
+    return res.status(200).json(brands)
+  }
+
+  if (req.method === 'POST') {
+    const { name } = req.body
+    const brand = await prisma.brand.create({ data: { name } })
+    return res.status(201).json(brand)
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/sites/[id].ts
+++ b/pages/api/sites/[id].ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+
+  if (req.method === 'GET') {
+    const site = await prisma.site.findUnique({ where: { id } })
+    return res.status(200).json(site)
+  }
+
+  if (req.method === 'PUT') {
+    const data = req.body
+    const site = await prisma.site.update({ where: { id }, data })
+    return res.status(200).json(site)
+  }
+
+  if (req.method === 'DELETE') {
+    await prisma.site.delete({ where: { id } })
+    return res.status(204).end()
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/sites/index.ts
+++ b/pages/api/sites/index.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const sites = await prisma.site.findMany()
+    return res.status(200).json(sites)
+  }
+
+  if (req.method === 'POST') {
+    const { name } = req.body
+    const site = await prisma.site.create({ data: { name } })
+    return res.status(201).json(site)
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/brands/[id].tsx
+++ b/pages/brands/[id].tsx
@@ -1,0 +1,63 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { Box, Button, FormControl, FormLabel, Heading, Input } from '@chakra-ui/react'
+import SidebarLayout from '../../components/SidebarLayout'
+import { prisma } from '../../lib/prisma'
+
+interface Brand {
+  id: number
+  name: string
+}
+
+export default function EditBrand({ brand }: { brand: Brand }) {
+  const router = useRouter()
+  const [form, setForm] = useState({ ...brand })
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  async function handleSave() {
+    await fetch(`/api/brands/${brand.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    router.push('/brands')
+  }
+
+  return (
+    <SidebarLayout>
+      <Box maxW='md' mx='auto'>
+        <Heading size='md' mb={4}>Editar Marca</Heading>
+        <FormControl mb={2}>
+          <FormLabel>Nombre</FormLabel>
+          <Input name='name' value={form.name} onChange={handleChange} />
+        </FormControl>
+        <Button onClick={handleSave} colorScheme='blue'>Guardar</Button>
+      </Box>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ params, ...context }) => {
+  const session = await getSession(context)
+  if (!session) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false
+      }
+    }
+  }
+
+  const id = Number(params?.id)
+  const brand = await prisma.brand.findUnique({ where: { id } })
+  if (!brand) {
+    return { notFound: true }
+  }
+  const serializedBrand = { ...brand, createdAt: brand.createdAt.toISOString() }
+  return { props: { brand: serializedBrand } }
+}

--- a/pages/brands/index.tsx
+++ b/pages/brands/index.tsx
@@ -1,0 +1,119 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import {
+  Box,
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  FormControl,
+  FormLabel,
+  Input,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr
+} from '@chakra-ui/react'
+import SidebarLayout from '../../components/SidebarLayout'
+import { prisma } from '../../lib/prisma'
+
+interface Brand {
+  id: number
+  name: string
+}
+
+export default function Brands({ brands }: { brands: Brand[] }) {
+  const router = useRouter()
+  const [form, setForm] = useState({ name: '' })
+  const [isOpen, setIsOpen] = useState(false)
+  const onClose = () => setIsOpen(false)
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  async function handleAdd() {
+    await fetch('/api/brands', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    setForm({ name: '' })
+    onClose()
+    router.reload()
+  }
+
+  async function handleDelete(id: number) {
+    await fetch(`/api/brands/${id}`, { method: 'DELETE' })
+    router.reload()
+  }
+
+  return (
+    <SidebarLayout>
+      <Box display='flex' justifyContent='space-between' alignItems='center' mb={4}>
+        <Box as='h1' fontSize='xl' fontWeight='bold'>Marcas</Box>
+        <Button colorScheme='blue' onClick={() => setIsOpen(true)}>Agregar</Button>
+      </Box>
+
+      <Drawer isOpen={isOpen} placement='right' onClose={onClose} size='md'>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerHeader>Agregar Marca</DrawerHeader>
+          <DrawerBody>
+            <FormControl mb={2}>
+              <FormLabel>Nombre</FormLabel>
+              <Input name='name' value={form.name} onChange={handleChange} />
+            </FormControl>
+          </DrawerBody>
+          <DrawerFooter>
+            <Button variant='outline' mr={3} onClick={onClose}>Cancelar</Button>
+            <Button colorScheme='blue' onClick={handleAdd}>Guardar</Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+
+      <Table variant='simple'>
+        <Thead>
+          <Tr>
+            <Th>Nombre</Th>
+            <Th>Acciones</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {brands.map((b) => (
+            <Tr key={b.id}>
+              <Td>{b.name}</Td>
+              <Td>
+                <Button size='sm' mr={2} onClick={() => router.push(`/brands/${b.id}`)}>Editar</Button>
+                <Button size='sm' colorScheme='red' onClick={() => handleDelete(b.id)}>Eliminar</Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context)
+  if (!session) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false
+      }
+    }
+  }
+
+  const brands = await prisma.brand.findMany()
+  const serializedBrands = brands.map((b) => ({ ...b, createdAt: b.createdAt.toISOString() }))
+  return { props: { brands: serializedBrands } }
+}

--- a/pages/inventory/[id].tsx
+++ b/pages/inventory/[id].tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next'
 import { getSession } from 'next-auth/react'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   Box,
   Button,
@@ -26,13 +26,22 @@ interface Device {
   serial?: string | null
 }
 
+interface Option { id: number; name: string }
+
 export default function EditDevice({ device }: { device: Device }) {
   const router = useRouter()
   const [form, setForm] = useState({ ...device })
+  const [sites, setSites] = useState<Option[]>([])
+  const [brands, setBrands] = useState<Option[]>([])
 
-  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
     setForm({ ...form, [e.target.name]: e.target.value })
   }
+
+  useEffect(() => {
+    fetch('/api/sites').then(res => res.json()).then(setSites)
+    fetch('/api/brands').then(res => res.json()).then(setBrands)
+  }, [])
 
   async function handleSave() {
     await fetch(`/api/devices/${device.id}`, {
@@ -57,7 +66,12 @@ export default function EditDevice({ device }: { device: Device }) {
         </FormControl>
         <FormControl mb={2}>
           <FormLabel>Sitio</FormLabel>
-          <Input name='sitio' value={form.sitio} onChange={handleChange} />
+          <select name='sitio' value={form.sitio} onChange={handleChange} style={{ width: '100%', padding: '8px', borderRadius: '4px' }}>
+            <option value=''>Seleccione...</option>
+            {sites.map((s) => (
+              <option key={s.id} value={s.name}>{s.name}</option>
+            ))}
+          </select>
         </FormControl>
         <FormControl mb={2}>
           <FormLabel>Rack</FormLabel>
@@ -69,7 +83,12 @@ export default function EditDevice({ device }: { device: Device }) {
         </FormControl>
         <FormControl mb={2}>
           <FormLabel>Marca</FormLabel>
-          <Input name='marca' value={form.marca} onChange={handleChange} />
+          <select name='marca' value={form.marca} onChange={handleChange} style={{ width: '100%', padding: '8px', borderRadius: '4px' }}>
+            <option value=''>Seleccione...</option>
+            {brands.map((b) => (
+              <option key={b.id} value={b.name}>{b.name}</option>
+            ))}
+          </select>
         </FormControl>
         <FormControl mb={2}>
           <FormLabel>Modelo</FormLabel>

--- a/pages/inventory/index.tsx
+++ b/pages/inventory/index.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next'
 import { getSession } from 'next-auth/react'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   Box,
   Button,
@@ -37,6 +37,8 @@ interface Device {
   serial?: string | null
 }
 
+interface Option { id: number; name: string }
+
 export default function Inventory({ devices }: { devices: Device[] }) {
   const router = useRouter()
   const [form, setForm] = useState({
@@ -52,11 +54,18 @@ export default function Inventory({ devices }: { devices: Device[] }) {
   })
   const [isOpen, setIsOpen] = useState(false)
   const [search, setSearch] = useState('')
+  const [sites, setSites] = useState<Option[]>([])
+  const [brands, setBrands] = useState<Option[]>([])
   const onClose = () => setIsOpen(false)
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     setForm({ ...form, [e.target.name]: e.target.value })
   }
+
+  useEffect(() => {
+    fetch('/api/sites').then(res => res.json()).then(setSites)
+    fetch('/api/brands').then(res => res.json()).then(setBrands)
+  }, [])
 
   async function handleAdd() {
     await fetch('/api/devices', {
@@ -122,7 +131,12 @@ export default function Inventory({ devices }: { devices: Device[] }) {
             </FormControl>
             <FormControl mb={2}>
               <FormLabel>Sitio</FormLabel>
-              <Input name='sitio' value={form.sitio} onChange={handleChange} />
+              <select name='sitio' value={form.sitio} onChange={handleChange} style={{ width: '100%', padding: '8px', borderRadius: '4px' }}>
+                <option value=''>Seleccione...</option>
+                {sites.map((s) => (
+                  <option key={s.id} value={s.name}>{s.name}</option>
+                ))}
+              </select>
             </FormControl>
             <FormControl mb={2}>
               <FormLabel>Rack</FormLabel>
@@ -134,7 +148,12 @@ export default function Inventory({ devices }: { devices: Device[] }) {
             </FormControl>
             <FormControl mb={2}>
               <FormLabel>Marca</FormLabel>
-              <Input name='marca' value={form.marca} onChange={handleChange} />
+              <select name='marca' value={form.marca} onChange={handleChange} style={{ width: '100%', padding: '8px', borderRadius: '4px' }}>
+                <option value=''>Seleccione...</option>
+                {brands.map((b) => (
+                  <option key={b.id} value={b.name}>{b.name}</option>
+                ))}
+              </select>
             </FormControl>
             <FormControl mb={2}>
               <FormLabel>Modelo</FormLabel>

--- a/pages/sites/[id].tsx
+++ b/pages/sites/[id].tsx
@@ -1,0 +1,63 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { Box, Button, FormControl, FormLabel, Heading, Input } from '@chakra-ui/react'
+import SidebarLayout from '../../components/SidebarLayout'
+import { prisma } from '../../lib/prisma'
+
+interface Site {
+  id: number
+  name: string
+}
+
+export default function EditSite({ site }: { site: Site }) {
+  const router = useRouter()
+  const [form, setForm] = useState({ ...site })
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  async function handleSave() {
+    await fetch(`/api/sites/${site.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    router.push('/sites')
+  }
+
+  return (
+    <SidebarLayout>
+      <Box maxW='md' mx='auto'>
+        <Heading size='md' mb={4}>Editar Sitio</Heading>
+        <FormControl mb={2}>
+          <FormLabel>Nombre</FormLabel>
+          <Input name='name' value={form.name} onChange={handleChange} />
+        </FormControl>
+        <Button onClick={handleSave} colorScheme='blue'>Guardar</Button>
+      </Box>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ params, ...context }) => {
+  const session = await getSession(context)
+  if (!session) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false
+      }
+    }
+  }
+
+  const id = Number(params?.id)
+  const site = await prisma.site.findUnique({ where: { id } })
+  if (!site) {
+    return { notFound: true }
+  }
+  const serializedSite = { ...site, createdAt: site.createdAt.toISOString() }
+  return { props: { site: serializedSite } }
+}

--- a/pages/sites/index.tsx
+++ b/pages/sites/index.tsx
@@ -1,0 +1,119 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import {
+  Box,
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  FormControl,
+  FormLabel,
+  Input,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr
+} from '@chakra-ui/react'
+import SidebarLayout from '../../components/SidebarLayout'
+import { prisma } from '../../lib/prisma'
+
+interface Site {
+  id: number
+  name: string
+}
+
+export default function Sites({ sites }: { sites: Site[] }) {
+  const router = useRouter()
+  const [form, setForm] = useState({ name: '' })
+  const [isOpen, setIsOpen] = useState(false)
+  const onClose = () => setIsOpen(false)
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  async function handleAdd() {
+    await fetch('/api/sites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    setForm({ name: '' })
+    onClose()
+    router.reload()
+  }
+
+  async function handleDelete(id: number) {
+    await fetch(`/api/sites/${id}`, { method: 'DELETE' })
+    router.reload()
+  }
+
+  return (
+    <SidebarLayout>
+      <Box display='flex' justifyContent='space-between' alignItems='center' mb={4}>
+        <Box as='h1' fontSize='xl' fontWeight='bold'>Sitios</Box>
+        <Button colorScheme='blue' onClick={() => setIsOpen(true)}>Agregar</Button>
+      </Box>
+
+      <Drawer isOpen={isOpen} placement='right' onClose={onClose} size='md'>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerHeader>Agregar Sitio</DrawerHeader>
+          <DrawerBody>
+            <FormControl mb={2}>
+              <FormLabel>Nombre</FormLabel>
+              <Input name='name' value={form.name} onChange={handleChange} />
+            </FormControl>
+          </DrawerBody>
+          <DrawerFooter>
+            <Button variant='outline' mr={3} onClick={onClose}>Cancelar</Button>
+            <Button colorScheme='blue' onClick={handleAdd}>Guardar</Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+
+      <Table variant='simple'>
+        <Thead>
+          <Tr>
+            <Th>Nombre</Th>
+            <Th>Acciones</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {sites.map((s) => (
+            <Tr key={s.id}>
+              <Td>{s.name}</Td>
+              <Td>
+                <Button size='sm' mr={2} onClick={() => router.push(`/sites/${s.id}`)}>Editar</Button>
+                <Button size='sm' colorScheme='red' onClick={() => handleDelete(s.id)}>Eliminar</Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context)
+  if (!session) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false
+      }
+    }
+  }
+
+  const sites = await prisma.site.findMany()
+  const serializedSites = sites.map((s) => ({ ...s, createdAt: s.createdAt.toISOString() }))
+  return { props: { sites: serializedSites } }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,3 +28,15 @@ model Device {
   serial         String?
   createdAt      DateTime @default(now())
 }
+
+model Site {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  createdAt DateTime @default(now())
+}
+
+model Brand {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- update sidebar style and add expandable menu for inventory sections
- add CRUD pages and APIs for sites and brands
- use select dropdowns for site and brand when editing or creating devices
- extend prisma schema with Site and Brand models

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686841d53f588322abecdce6db00c226