### PR TITLE
Add description and location fields

### DIFF
--- a/pages/api/brands/index.ts
+++ b/pages/api/brands/index.ts
@@ -8,8 +8,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   if (req.method === 'POST') {
-    const { name } = req.body
-    const brand = await prisma.brand.create({ data: { name } })
+    const { name, descripcion } = req.body
+    const brand = await prisma.brand.create({ data: { name, descripcion } })
     return res.status(201).json(brand)
   }
 

--- a/pages/api/devices/index.ts
+++ b/pages/api/devices/index.ts
@@ -17,7 +17,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       marca,
       modelo,
       versionSoftware,
-      serial
+      serial,
+      assetTag,
+      descripcion
     } = req.body
 
     const device = await prisma.device.create({
@@ -30,7 +32,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         marca,
         modelo,
         versionSoftware,
-        serial
+        serial,
+        assetTag,
+        descripcion
       }
     })
     return res.status(201).json(device)

--- a/pages/api/sites/index.ts
+++ b/pages/api/sites/index.ts
@@ -8,8 +8,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   if (req.method === 'POST') {
-    const { name } = req.body
-    const site = await prisma.site.create({ data: { name } })
+    const { name, ubicacion, descripcion } = req.body
+    const site = await prisma.site.create({ data: { name, ubicacion, descripcion } })
     return res.status(201).json(site)
   }
 

--- a/pages/brands/[id].tsx
+++ b/pages/brands/[id].tsx
@@ -9,6 +9,7 @@ import { prisma } from '../../lib/prisma'
 interface Brand {
   id: number
   name: string
+  descripcion?: string | null
 }
 
 export default function EditBrand({ brand }: { brand: Brand }) {
@@ -35,6 +36,10 @@ export default function EditBrand({ brand }: { brand: Brand }) {
         <FormControl mb={2}>
           <FormLabel>Nombre</FormLabel>
           <Input name='name' value={form.name} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Descripción</FormLabel>
+          <Input name='descripcion' value={form.descripcion ?? ''} onChange={handleChange} />
         </FormControl>
         <Button onClick={handleSave} colorScheme='blue'>Guardar</Button>
       </Box>

--- a/pages/brands/index.tsx
+++ b/pages/brands/index.tsx
@@ -27,11 +27,12 @@ import { prisma } from '../../lib/prisma'
 interface Brand {
   id: number
   name: string
+  descripcion?: string | null
 }
 
 export default function Brands({ brands }: { brands: Brand[] }) {
   const router = useRouter()
-  const [form, setForm] = useState({ name: '' })
+  const [form, setForm] = useState({ name: '', descripcion: '' })
   const [isOpen, setIsOpen] = useState(false)
   const onClose = () => setIsOpen(false)
 
@@ -45,7 +46,7 @@ export default function Brands({ brands }: { brands: Brand[] }) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(form)
     })
-    setForm({ name: '' })
+    setForm({ name: '', descripcion: '' })
     onClose()
     router.reload()
   }
@@ -71,6 +72,10 @@ export default function Brands({ brands }: { brands: Brand[] }) {
               <FormLabel>Nombre</FormLabel>
               <Input name='name' value={form.name} onChange={handleChange} />
             </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Descripción</FormLabel>
+              <Input name='descripcion' value={form.descripcion} onChange={handleChange} />
+            </FormControl>
           </DrawerBody>
           <DrawerFooter>
             <Button variant='outline' mr={3} onClick={onClose}>Cancelar</Button>
@@ -83,6 +88,7 @@ export default function Brands({ brands }: { brands: Brand[] }) {
         <Thead>
           <Tr>
             <Th>Nombre</Th>
+            <Th>Descripción</Th>
             <Th>Acciones</Th>
           </Tr>
         </Thead>
@@ -90,6 +96,7 @@ export default function Brands({ brands }: { brands: Brand[] }) {
           {brands.map((b) => (
             <Tr key={b.id}>
               <Td>{b.name}</Td>
+              <Td>{b.descripcion}</Td>
               <Td>
                 <Button size='sm' mr={2} onClick={() => router.push(`/brands/${b.id}`)}>Editar</Button>
                 <Button size='sm' colorScheme='red' onClick={() => handleDelete(b.id)}>Eliminar</Button>

--- a/pages/inventory/[id].tsx
+++ b/pages/inventory/[id].tsx
@@ -24,6 +24,8 @@ interface Device {
   modelo: string
   versionSoftware: string
   serial?: string | null
+  assetTag?: string | null
+  descripcion?: string | null
 }
 
 interface Option { id: number; name: string }
@@ -101,6 +103,14 @@ export default function EditDevice({ device }: { device: Device }) {
         <FormControl mb={4}>
           <FormLabel>Serial</FormLabel>
           <Input name='serial' value={form.serial ?? ''} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={4}>
+          <FormLabel>Asset Tag</FormLabel>
+          <Input name='assetTag' value={form.assetTag ?? ''} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={4}>
+          <FormLabel>Descripción</FormLabel>
+          <Input name='descripcion' value={form.descripcion ?? ''} onChange={handleChange} />
         </FormControl>
         <Button onClick={handleSave} colorScheme='blue'>Guardar</Button>
       </Box>

--- a/pages/inventory/index.tsx
+++ b/pages/inventory/index.tsx
@@ -35,6 +35,8 @@ interface Device {
   modelo: string
   versionSoftware: string
   serial?: string | null
+  assetTag?: string | null
+  descripcion?: string | null
 }
 
 interface Option { id: number; name: string }
@@ -50,7 +52,9 @@ export default function Inventory({ devices }: { devices: Device[] }) {
     marca: '',
     modelo: '',
     versionSoftware: '',
-    serial: ''
+    serial: '',
+    assetTag: '',
+    descripcion: ''
   })
   const [isOpen, setIsOpen] = useState(false)
   const [search, setSearch] = useState('')
@@ -82,7 +86,9 @@ export default function Inventory({ devices }: { devices: Device[] }) {
       marca: '',
       modelo: '',
       versionSoftware: '',
-      serial: ''
+      serial: '',
+      assetTag: '',
+      descripcion: ''
     })
     onClose()
     router.reload()
@@ -167,6 +173,14 @@ export default function Inventory({ devices }: { devices: Device[] }) {
               <FormLabel>Serial</FormLabel>
               <Input name='serial' value={form.serial} onChange={handleChange} />
             </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Asset Tag</FormLabel>
+              <Input name='assetTag' value={form.assetTag} onChange={handleChange} />
+            </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Descripción</FormLabel>
+              <Input name='descripcion' value={form.descripcion} onChange={handleChange} />
+            </FormControl>
           </DrawerBody>
           <DrawerFooter>
             <Button variant='outline' mr={3} onClick={onClose}>Cancelar</Button>
@@ -186,6 +200,8 @@ export default function Inventory({ devices }: { devices: Device[] }) {
             <Th>Modelo</Th>
             <Th>Versión</Th>
             <Th>Serial</Th>
+            <Th>Asset Tag</Th>
+            <Th>Descripción</Th>
             <Th>Acciones</Th>
           </Tr>
         </Thead>
@@ -201,6 +217,8 @@ export default function Inventory({ devices }: { devices: Device[] }) {
               <Td>{d.modelo}</Td>
               <Td>{d.versionSoftware}</Td>
               <Td>{d.serial}</Td>
+              <Td>{d.assetTag}</Td>
+              <Td>{d.descripcion}</Td>
               <Td>
                 <Button size='sm' mr={2} onClick={() => router.push(`/inventory/${d.id}`)}>Editar</Button>
                 <Button size='sm' colorScheme='red' onClick={() => handleDelete(d.id)}>Eliminar</Button>

--- a/pages/sites/[id].tsx
+++ b/pages/sites/[id].tsx
@@ -9,6 +9,8 @@ import { prisma } from '../../lib/prisma'
 interface Site {
   id: number
   name: string
+  ubicacion?: string | null
+  descripcion?: string | null
 }
 
 export default function EditSite({ site }: { site: Site }) {
@@ -35,6 +37,14 @@ export default function EditSite({ site }: { site: Site }) {
         <FormControl mb={2}>
           <FormLabel>Nombre</FormLabel>
           <Input name='name' value={form.name} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Ubicación</FormLabel>
+          <Input name='ubicacion' value={form.ubicacion ?? ''} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Descripción</FormLabel>
+          <Input name='descripcion' value={form.descripcion ?? ''} onChange={handleChange} />
         </FormControl>
         <Button onClick={handleSave} colorScheme='blue'>Guardar</Button>
       </Box>

--- a/pages/sites/index.tsx
+++ b/pages/sites/index.tsx
@@ -27,11 +27,13 @@ import { prisma } from '../../lib/prisma'
 interface Site {
   id: number
   name: string
+  ubicacion?: string | null
+  descripcion?: string | null
 }
 
 export default function Sites({ sites }: { sites: Site[] }) {
   const router = useRouter()
-  const [form, setForm] = useState({ name: '' })
+  const [form, setForm] = useState({ name: '', ubicacion: '', descripcion: '' })
   const [isOpen, setIsOpen] = useState(false)
   const onClose = () => setIsOpen(false)
 
@@ -45,7 +47,7 @@ export default function Sites({ sites }: { sites: Site[] }) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(form)
     })
-    setForm({ name: '' })
+    setForm({ name: '', ubicacion: '', descripcion: '' })
     onClose()
     router.reload()
   }
@@ -71,6 +73,14 @@ export default function Sites({ sites }: { sites: Site[] }) {
               <FormLabel>Nombre</FormLabel>
               <Input name='name' value={form.name} onChange={handleChange} />
             </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Ubicación</FormLabel>
+              <Input name='ubicacion' value={form.ubicacion} onChange={handleChange} />
+            </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Descripción</FormLabel>
+              <Input name='descripcion' value={form.descripcion} onChange={handleChange} />
+            </FormControl>
           </DrawerBody>
           <DrawerFooter>
             <Button variant='outline' mr={3} onClick={onClose}>Cancelar</Button>
@@ -83,6 +93,8 @@ export default function Sites({ sites }: { sites: Site[] }) {
         <Thead>
           <Tr>
             <Th>Nombre</Th>
+            <Th>Ubicación</Th>
+            <Th>Descripción</Th>
             <Th>Acciones</Th>
           </Tr>
         </Thead>
@@ -90,6 +102,8 @@ export default function Sites({ sites }: { sites: Site[] }) {
           {sites.map((s) => (
             <Tr key={s.id}>
               <Td>{s.name}</Td>
+              <Td>{s.ubicacion}</Td>
+              <Td>{s.descripcion}</Td>
               <Td>
                 <Button size='sm' mr={2} onClick={() => router.push(`/sites/${s.id}`)}>Editar</Button>
                 <Button size='sm' colorScheme='red' onClick={() => handleDelete(s.id)}>Eliminar</Button>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,17 +26,22 @@ model Device {
   modelo         String
   versionSoftware String
   serial         String?
+  assetTag       String?
+  descripcion    String?
   createdAt      DateTime @default(now())
 }
 
 model Site {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  ubicacion String?
+  descripcion String?
   createdAt DateTime @default(now())
 }
 
 model Brand {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  descripcion String?
   createdAt DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- extend Prisma models with new description, location, and asset tag fields
- allow specifying these fields in site, brand, and device API endpoints
- update forms for brands, sites, and inventory to capture the new data

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next/router' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686845f347448322a10101ec74716cea