### PR TITLE
Add Chakra UI bar charts to dashboard

### DIFF
--- a/components/BarChart.tsx
+++ b/components/BarChart.tsx
@@ -1,0 +1,35 @@
+import { Box, Flex, Text } from '@chakra-ui/react'
+
+interface DataItem {
+  label: string
+  value: number
+}
+
+interface BarChartProps {
+  data: DataItem[]
+  maxHeight?: number | string
+}
+
+export default function BarChart({ data, maxHeight = 200 }: BarChartProps) {
+  const maxValue = Math.max(...data.map((d) => d.value), 0)
+  return (
+    <Flex align="flex-end" gap={2} h={maxHeight}>
+      {data.map((d) => (
+        <Flex key={d.label} direction="column" align="center" flex="1">
+          <Box
+            w="100%"
+            bg="blue.500"
+            borderRadius="md"
+            h={maxValue ? `${(d.value / maxValue) * 100}%` : '0%'}
+          />
+          <Text mt={1} fontSize="sm" noOfLines={1}>
+            {d.label}
+          </Text>
+          <Text fontSize="sm" fontWeight="bold">
+            {d.value}
+          </Text>
+        </Flex>
+      ))}
+    </Flex>
+  )
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -15,6 +15,7 @@ import {
   Td
 } from '@chakra-ui/react'
 import SidebarLayout from '../components/SidebarLayout'
+import BarChart from '../components/BarChart'
 import { prisma } from '../lib/prisma'
 
 interface Stats {
@@ -48,7 +49,14 @@ export default function Dashboard({ stats }: { stats: Stats }) {
 
         <Box mb={8}>
           <Box as='h2' fontSize='lg' fontWeight='bold' mb={2}>Equipos por Sitio</Box>
-          <Table variant='simple' size='sm'>
+          <BarChart
+            data={stats.devicesBySite.map((s) => ({
+              label: s.sitio || 'N/A',
+              value: s._count._all
+            }))}
+            maxHeight={200}
+          />
+          <Table variant='simple' size='sm' mt={4}>
             <Thead>
               <Tr>
                 <Th>Sitio</Th>
@@ -68,7 +76,14 @@ export default function Dashboard({ stats }: { stats: Stats }) {
 
         <Box mb={8}>
           <Box as='h2' fontSize='lg' fontWeight='bold' mb={2}>Equipos por Marca</Box>
-          <Table variant='simple' size='sm'>
+          <BarChart
+            data={stats.devicesByBrand.map((b) => ({
+              label: b.marca || 'N/A',
+              value: b._count._all
+            }))}
+            maxHeight={200}
+          />
+          <Table variant='simple' size='sm' mt={4}>
             <Thead>
               <Tr>
                 <Th>Marca</Th>


### PR DESCRIPTION
## Summary
- add reusable `BarChart` component for simple graphs
- display bar charts for devices by site and brand on the dashboard

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686853b821688322a48477c0d1e275bc