### PR TITLE
Fix inventory serialization

### DIFF
--- a/pages/inventory/[id].tsx
+++ b/pages/inventory/[id].tsx
@@ -153,6 +153,8 @@ export const getServerSideProps: GetServerSideProps = async ({ params, ...contex
     ...device,
     createdAt: device.createdAt.toISOString(),
     credential: device.credential
+      ? { ...device.credential, createdAt: device.credential.createdAt.toISOString() }
+      : null
   }
   return {
     props: { device: serializedDevice }

--- a/pages/inventory/index.tsx
+++ b/pages/inventory/index.tsx
@@ -266,6 +266,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     ...d,
     createdAt: d.createdAt.toISOString(),
     credential: d.credential
+      ? { ...d.credential, createdAt: d.credential.createdAt.toISOString() }
+      : null
   }))
   return {
     props: { devices: serializedDevices }


### PR DESCRIPTION
## Summary
- handle nested credential timestamps in inventory pages

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685fc449d8832291e6d6d6599d8f8e