### PR TITLE
Add backup scheduler and storage pages

### DIFF
--- a/components/SidebarLayout.tsx
+++ b/components/SidebarLayout.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Button, VStack, Text, Collapse } from '@chakra-ui/react'
 
 export default function SidebarLayout({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false)
+  const [openBackups, setOpenBackups] = useState(false)
   return (
     <Flex minH='100vh'>
       <Box w='220px' bg='gray.800' color='white' p={4}>
@@ -75,6 +76,41 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
                 size='sm'
               >
                 Contraseñas
+              </Button>
+            </VStack>
+          </Collapse>
+          <Button
+            bg='white'
+            color='gray.800'
+            _hover={{ bg: 'gray.200' }}
+            w='100%'
+            onClick={() => setOpenBackups(!openBackups)}
+          >
+            Backups
+          </Button>
+          <Collapse in={openBackups} animateOpacity>
+            <VStack align='stretch' spacing={1} mt={1} pl={2}>
+              <Button
+                as={NextLink}
+                href='/backups/programacion'
+                bg='white'
+                color='gray.800'
+                _hover={{ bg: 'gray.200' }}
+                w='100%'
+                size='sm'
+              >
+                Programacion
+              </Button>
+              <Button
+                as={NextLink}
+                href='/backups/bodega'
+                bg='white'
+                color='gray.800'
+                _hover={{ bg: 'gray.200' }}
+                w='100%'
+                size='sm'
+              >
+                Bodega
               </Button>
             </VStack>
           </Collapse>

--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -1,0 +1,41 @@
+import { prisma } from './prisma'
+import { exec } from 'child_process'
+
+let started = false
+
+function runBackup(scheduleId: number) {
+  prisma.schedule.findUnique({ where: { id: scheduleId }, include: { device: true, credential: true } })
+    .then(async sched => {
+      if (!sched) return
+      const command = sched.device.marca.toLowerCase().includes('mikrotik') ? 'export' : 'show run'
+      const sshCmd = `ssh ${sched.credential.usuario}@${sched.device.ipGestion} "${command}"`
+      exec(sshCmd, async (err, stdout, stderr) => {
+        const content = err ? stderr : stdout
+        await prisma.backup.create({
+          data: {
+            deviceId: sched.deviceId,
+            content
+          }
+        })
+        const next = getNextRun(sched.period)
+        await prisma.schedule.update({ where: { id: sched.id }, data: { nextRun: next } })
+      })
+    })
+}
+
+function getNextRun(period: string) {
+  const now = new Date()
+  if (period === 'DAILY') now.setDate(now.getDate() + 1)
+  else if (period === 'WEEKLY') now.setDate(now.getDate() + 7)
+  else if (period === 'MONTHLY') now.setMonth(now.getMonth() + 1)
+  return now
+}
+
+export function startScheduler() {
+  if (started) return
+  started = true
+  setInterval(async () => {
+    const due = await prisma.schedule.findMany({ where: { nextRun: { lte: new Date() } } })
+    due.forEach(s => runBackup(s.id))
+  }, 60000)
+}

--- a/pages/api/backups/[id].ts
+++ b/pages/api/backups/[id].ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+  if (req.method === 'GET') {
+    const backups = await prisma.backup.findMany({ where: { deviceId: id } })
+    return res.status(200).json(backups)
+  }
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/backups/index.ts
+++ b/pages/api/backups/index.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const backups = await prisma.backup.findMany()
+    return res.status(200).json(backups)
+  }
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/schedules/index.ts
+++ b/pages/api/schedules/index.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+import { startScheduler } from '../../../lib/scheduler'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  startScheduler()
+  if (req.method === 'GET') {
+    const schedules = await prisma.schedule.findMany({ include: { device: true, credential: true } })
+    return res.status(200).json(schedules)
+  }
+
+  if (req.method === 'POST') {
+    const { deviceId, credentialId, period } = req.body
+    const nextRun = new Date()
+    const sched = await prisma.schedule.create({ data: { deviceId: Number(deviceId), credentialId: Number(credentialId), period, nextRun } })
+    return res.status(201).json(sched)
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/backups/bodega/[id].tsx
+++ b/pages/backups/bodega/[id].tsx
@@ -1,0 +1,50 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Button } from '@chakra-ui/react'
+import SidebarLayout from '../../../components/SidebarLayout'
+import { prisma } from '../../../lib/prisma'
+
+interface Backup { id: number; content: string; createdAt: string }
+interface Device { id: number; nombre: string }
+
+export default function Backups({ backups, device }: { backups: Backup[]; device: Device }) {
+  const router = useRouter()
+  return (
+    <SidebarLayout>
+      <Box display='flex' alignItems='center' mb={4}>
+        <Button mr={2} onClick={() => router.push('/backups/bodega')}>Volver</Button>
+        <Box as='h1' fontSize='xl' fontWeight='bold'>Backups de {device.nombre}</Box>
+      </Box>
+      <Table variant='simple'>
+        <Thead>
+          <Tr>
+            <Th>Fecha</Th>
+            <Th>Contenido</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {backups.map(b => (
+            <Tr key={b.id}>
+              <Td>{new Date(b.createdAt).toLocaleString()}</Td>
+              <Td>{b.content}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ params, ...context }) => {
+  const session = await getSession(context)
+  if (!session) {
+    return { redirect: { destination: '/login', permanent: false } }
+  }
+  const id = Number(params?.id)
+  const device = await prisma.device.findUnique({ where: { id }, select: { id: true, nombre: true } })
+  if (!device) return { notFound: true }
+  const backups = await prisma.backup.findMany({ where: { deviceId: id } })
+  const serialized = backups.map(b => ({ ...b, createdAt: b.createdAt.toISOString() }))
+  return { props: { backups: serialized, device } }
+}

--- a/pages/backups/bodega/index.tsx
+++ b/pages/backups/bodega/index.tsx
@@ -1,0 +1,44 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Button } from '@chakra-ui/react'
+import SidebarLayout from '../../../components/SidebarLayout'
+import { prisma } from '../../../lib/prisma'
+
+interface Device { id: number; nombre: string }
+
+export default function Bodega({ devices }: { devices: Device[] }) {
+  const router = useRouter()
+  return (
+    <SidebarLayout>
+      <Box as='h1' fontSize='xl' fontWeight='bold' mb={4}>Bodega Backups</Box>
+      <Table variant='simple'>
+        <Thead>
+          <Tr>
+            <Th>Equipo</Th>
+            <Th>Acciones</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {devices.map(d => (
+            <Tr key={d.id}>
+              <Td>{d.nombre}</Td>
+              <Td>
+                <Button size='sm' onClick={() => router.push(`/backups/bodega/${d.id}`)}>Ver</Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context)
+  if (!session) {
+    return { redirect: { destination: '/login', permanent: false } }
+  }
+  const devices = await prisma.device.findMany({ select: { id: true, nombre: true } })
+  return { props: { devices } }
+}

--- a/pages/backups/programacion.tsx
+++ b/pages/backups/programacion.tsx
@@ -1,0 +1,113 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState, useEffect } from 'react'
+import {
+  Box, Button, Drawer, DrawerBody, DrawerContent, DrawerFooter,
+  DrawerHeader, DrawerOverlay, FormControl, FormLabel, Input, Table,
+  Thead, Tbody, Tr, Th, Td, Select
+} from '@chakra-ui/react'
+import SidebarLayout from '../../components/SidebarLayout'
+import { prisma } from '../../lib/prisma'
+
+interface Device { id: number; nombre: string }
+interface Credential { id: number; usuario: string }
+interface Schedule { id: number; device: Device; credential: Credential; period: string; nextRun: string }
+
+export default function Programacion({ devices, creds, schedules }: { devices: Device[]; creds: Credential[]; schedules: Schedule[] }) {
+  const router = useRouter()
+  const [form, setForm] = useState({ deviceId: '', credentialId: '', period: 'DAILY' })
+  const [isOpen, setIsOpen] = useState(false)
+  const onClose = () => setIsOpen(false)
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  async function handleAdd() {
+    await fetch('/api/schedules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...form, deviceId: Number(form.deviceId), credentialId: Number(form.credentialId) })
+    })
+    onClose()
+    router.reload()
+  }
+
+  return (
+    <SidebarLayout>
+      <Box display='flex' justifyContent='space-between' alignItems='center' mb={4}>
+        <Box as='h1' fontSize='xl' fontWeight='bold'>Programación de Backups</Box>
+        <Button colorScheme='blue' onClick={() => setIsOpen(true)}>Agregar</Button>
+      </Box>
+
+      <Drawer isOpen={isOpen} placement='right' onClose={onClose} size='md'>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerHeader>Nueva Programación</DrawerHeader>
+          <DrawerBody>
+            <FormControl mb={2}>
+              <FormLabel>Equipo</FormLabel>
+              <Select name='deviceId' value={form.deviceId} onChange={handleChange}>
+                <option value=''>Seleccione...</option>
+                {devices.map(d => <option key={d.id} value={d.id}>{d.nombre}</option>)}
+              </Select>
+            </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Credencial</FormLabel>
+              <Select name='credentialId' value={form.credentialId} onChange={handleChange}>
+                <option value=''>Seleccione...</option>
+                {creds.map(c => <option key={c.id} value={c.id}>{c.usuario}</option>)}
+              </Select>
+            </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Periodo</FormLabel>
+              <Select name='period' value={form.period} onChange={handleChange}>
+                <option value='DAILY'>1 Día</option>
+                <option value='WEEKLY'>1 Semana</option>
+                <option value='MONTHLY'>1 Mes</option>
+              </Select>
+            </FormControl>
+          </DrawerBody>
+          <DrawerFooter>
+            <Button variant='outline' mr={3} onClick={onClose}>Cancelar</Button>
+            <Button colorScheme='blue' onClick={handleAdd}>Guardar</Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+
+      <Table variant='simple'>
+        <Thead>
+          <Tr>
+            <Th>Equipo</Th>
+            <Th>Usuario</Th>
+            <Th>Periodo</Th>
+            <Th>Próxima Ejecución</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {schedules.map(s => (
+            <Tr key={s.id}>
+              <Td>{s.device.nombre}</Td>
+              <Td>{s.credential.usuario}</Td>
+              <Td>{s.period}</Td>
+              <Td>{new Date(s.nextRun).toLocaleString()}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context)
+  if (!session) {
+    return { redirect: { destination: '/login', permanent: false } }
+  }
+  const devices = await prisma.device.findMany({ select: { id: true, nombre: true } })
+  const creds = await prisma.credential.findMany({ select: { id: true, usuario: true } })
+  const schedules = await prisma.schedule.findMany({ include: { device: true, credential: true } })
+  const serialized = schedules.map(s => ({ ...s, nextRun: s.nextRun.toISOString(), createdAt: s.createdAt.toISOString() }))
+  return { props: { devices, creds, schedules: serialized } }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,3 +55,22 @@ model Credential {
   createdAt  DateTime  @default(now())
   devices    Device[]
 }
+
+model Backup {
+  id        Int      @id @default(autoincrement())
+  device    Device   @relation(fields: [deviceId], references: [id])
+  deviceId  Int
+  content   String
+  createdAt DateTime @default(now())
+}
+
+model Schedule {
+  id          Int        @id @default(autoincrement())
+  device      Device     @relation(fields: [deviceId], references: [id])
+  deviceId    Int
+  credential  Credential @relation(fields: [credentialId], references: [id])
+  credentialId Int
+  period      String
+  nextRun     DateTime
+  createdAt   DateTime   @default(now())
+}


### PR DESCRIPTION
## Summary
- add Backup and Schedule models
- implement scheduler helper with basic SSH call
- provide API routes for backup history and scheduling
- add pages for backup programming and storage
- extend sidebar with new menu

## Testing
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868634b589483229dd8a8dc6396d639