### PR TITLE
Add SSH validation for new inventory devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,17 +8,18 @@
     "prisma": "prisma"
   },
   "dependencies": {
-    "next": "13.5.6",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "next-auth": "4.22.1",
-    "@prisma/client": "5.1.1",
-    "bcryptjs": "2.4.3",
     "@chakra-ui/react": "^2.7.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@prisma/client": "5.1.1",
+    "bcryptjs": "2.4.3",
     "framer-motion": "^10.12.16",
-    "recharts": "^2.8.0"
+    "next": "13.5.6",
+    "next-auth": "4.22.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "recharts": "^2.8.0",
+    "ssh2": "^1.15.0"
   },
   "devDependencies": {
     "prisma": "5.1.1",

--- a/pages/api/test-ssh.ts
+++ b/pages/api/test-ssh.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { Client } from 'ssh2'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ message: 'Method not allowed' })
+    return
+  }
+
+  const { host, username, password } = req.body
+  if (!host || !username || !password) {
+    res.status(400).json({ message: 'Missing parameters' })
+    return
+  }
+
+  const conn = new Client()
+  conn.on('ready', () => {
+    conn.end()
+    res.status(200).json({ success: true })
+  }).on('error', (err) => {
+    res.status(200).json({ success: false, error: err.message })
+  }).connect({
+    host,
+    username,
+    password,
+    readyTimeout: 5000
+  })
+}

--- a/pages/inventory/[id].tsx
+++ b/pages/inventory/[id].tsx
@@ -31,7 +31,7 @@ interface Device {
 }
 
 interface Option { id: number; name: string }
-interface CredentialOption { id: number; usuario: string }
+interface CredentialOption { id: number; usuario: string; contrasena: string }
 
 export default function EditDevice({ device }: { device: Device }) {
   const router = useRouter()


### PR DESCRIPTION
## Summary
- add `ssh2` dependency
- create new API route to test SSH connection
- verify all fields filled and check SSH reachability before adding a device
- show connection errors in the add-device drawer
- extend credential interface with password

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf237ad488322bfb981a472160090