### PR TITLE
Handle all interface lines and show table

### DIFF
--- a/pages/api/devices/index.ts
+++ b/pages/api/devices/index.ts
@@ -58,13 +58,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         if (board) data.boardName = board[1].trim()
         if (host) data.hostname = host[1].trim()
         ifOut.split('\n').forEach((l) => {
-          const match = /set \[ find default-name=(\S+) \].* name=(\S+)/.exec(l)
-          if (!match) return
-          const iface = match[1]
-          let desc = match[2]
-          const prefix = `${iface}-`
-          if (desc.startsWith(prefix)) desc = desc.slice(prefix.length)
-          interfaces.push({ name: iface, description: desc || undefined })
+          l = l.trim()
+          if (!l.startsWith('set')) return
+          const def = /default-name=(\S+)/.exec(l)
+          if (!def) return
+          const iface = def[1]
+          let desc: string | undefined
+          const nameMatch = /name=("([^"]+)"|\S+)/.exec(l)
+          if (nameMatch) {
+            let val = nameMatch[2] || nameMatch[1]
+            val = val.replace(/^"|"$/g, '')
+            const prefix = `${iface}-`
+            if (val.startsWith(prefix)) val = val.slice(prefix.length)
+            desc = val.trim() || undefined
+          }
+          interfaces.push({ name: iface, description: desc })
         })
       } catch (e) {
         console.error(e)

--- a/pages/inventory/[id].tsx
+++ b/pages/inventory/[id].tsx
@@ -4,8 +4,12 @@ import {
   Box,
   Heading,
   Text,
-  List,
-  ListItem,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
   Stack,
   Flex
 } from '@chakra-ui/react'
@@ -83,14 +87,22 @@ export default function ViewDevice({ device }: { device: Device }) {
             <Box mt={4}>
               <Heading size='sm' mb={2}>Interfaces</Heading>
               <Text mb={2} fontWeight='bold'>Cantidad: {device.interfaces.length}</Text>
-              <List spacing={1}>
-                {device.interfaces.map((i) => (
-                  <ListItem key={i.id}>
-                    {i.name}
-                    {i.description ? ` - ${i.description}` : ''}
-                  </ListItem>
-                ))}
-              </List>
+              <Table size='sm'>
+                <Thead>
+                  <Tr>
+                    <Th>Nombre</Th>
+                    <Th>Descripci\u00f3n</Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {device.interfaces.map((i) => (
+                    <Tr key={i.id}>
+                      <Td>{i.name}</Td>
+                      <Td>{i.description || '-'}</Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
             </Box>
           )}
         </Box>


### PR DESCRIPTION
## Summary
- parse Mikrotik interface exports even when there is no name field
- show device interfaces in a table on the inventory detail view

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1519694c832283272df087c06150