### PR TITLE
Add topology provisioning page

### DIFF
--- a/components/SidebarLayout.tsx
+++ b/components/SidebarLayout.tsx
@@ -6,6 +6,7 @@ import { Box, Flex, Button, VStack, Text, Collapse } from '@chakra-ui/react'
 export default function SidebarLayout({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false)
   const [openBackups, setOpenBackups] = useState(false)
+  const [openProv, setOpenProv] = useState(false)
   return (
     <Flex minH='100vh'>
       <Box w='220px' bg='gray.800' color='white' p={4} display='flex' flexDirection='column' justifyContent='space-between'>
@@ -102,6 +103,30 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
                 size='sm'
               >
                 Bodega
+              </Button>
+            </VStack>
+          </Collapse>
+          <Button
+            bg='white'
+            color='gray.800'
+            _hover={{ bg: 'gray.200' }}
+            w='100%'
+            onClick={() => setOpenProv(!openProv)}
+          >
+            Aprovisionamiento
+          </Button>
+          <Collapse in={openProv} animateOpacity>
+            <VStack align='stretch' spacing={1} mt={1} pl={2}>
+              <Button
+                as={NextLink}
+                href='/aprovisionamiento/topologia'
+                bg='white'
+                color='gray.800'
+                _hover={{ bg: 'gray.200' }}
+                w='100%'
+                size='sm'
+              >
+                Topologia
               </Button>
             </VStack>
           </Collapse>

--- a/pages/aprovisionamiento/topologia.tsx
+++ b/pages/aprovisionamiento/topologia.tsx
@@ -1,0 +1,96 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useState } from 'react'
+import { Box, Heading, Select, Button, Flex } from '@chakra-ui/react'
+import SidebarLayout from '../../components/SidebarLayout'
+import { prisma } from '../../lib/prisma'
+
+type Interface = { id: number; name: string; description?: string | null }
+type Device = { id: number; ipGestion: string; hostname?: string | null; interfaces: Interface[] }
+
+export default function Topologia({ devices }: { devices: Device[] }) {
+  const [srcId, setSrcId] = useState('')
+  const [srcIf, setSrcIf] = useState('')
+  const [dstId, setDstId] = useState('')
+  const [dstIf, setDstIf] = useState('')
+  const [connections, setConnections] = useState<{ srcId: number; srcIf: string; dstId: number; dstIf: string }[]>([])
+
+  const positions = devices.map((_, idx) => ({ x: 100 + idx * 150, y: 100 }))
+
+  function handleAdd() {
+    if (!srcId || !srcIf || !dstId || !dstIf) return
+    setConnections([...connections, { srcId: Number(srcId), srcIf, dstId: Number(dstId), dstIf }])
+  }
+
+  return (
+    <SidebarLayout>
+      <Box>
+        <Heading size='md' mb={4}>Topolog\u00eda</Heading>
+        <svg width='100%' height='300' style={{ border: '1px solid #ccc' }}>
+          {devices.map((d, i) => (
+            <g key={d.id} transform={`translate(${positions[i].x}, ${positions[i].y})`}>
+              <circle r='20' fill='#90cdf4' />
+              <text x='-15' y='35' fontSize='10'>{d.hostname || d.ipGestion}</text>
+            </g>
+          ))}
+          {connections.map((c, idx) => {
+            const si = devices.findIndex(d => d.id === c.srcId)
+            const di = devices.findIndex(d => d.id === c.dstId)
+            if (si === -1 || di === -1) return null
+            const s = positions[si]
+            const t = positions[di]
+            return <line key={idx} x1={s.x} y1={s.y} x2={t.x} y2={t.y} stroke='black' />
+          })}
+        </svg>
+        <Flex mt={4} gap={2} flexWrap='wrap'>
+          <Select placeholder='Origen' value={srcId} onChange={e => { setSrcId(e.target.value); setSrcIf('') }}>
+            {devices.map(d => (
+              <option key={d.id} value={d.id}>{d.hostname || d.ipGestion}</option>
+            ))}
+          </Select>
+          <Select placeholder='Interfaz Origen' value={srcIf} onChange={e => setSrcIf(e.target.value)}>
+            {devices.find(d => d.id === Number(srcId))?.interfaces.map(i => (
+              <option key={i.id} value={i.name}>{i.name}</option>
+            ))}
+          </Select>
+          <Select placeholder='Destino' value={dstId} onChange={e => { setDstId(e.target.value); setDstIf('') }}>
+            {devices.map(d => (
+              <option key={d.id} value={d.id}>{d.hostname || d.ipGestion}</option>
+            ))}
+          </Select>
+          <Select placeholder='Interfaz Destino' value={dstIf} onChange={e => setDstIf(e.target.value)}>
+            {devices.find(d => d.id === Number(dstId))?.interfaces.map(i => (
+              <option key={i.id} value={i.name}>{i.name}</option>
+            ))}
+          </Select>
+          <Button onClick={handleAdd}>Conectar</Button>
+        </Flex>
+      </Box>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context)
+  if (!session) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false
+      }
+    }
+  }
+
+  const devices = await prisma.device.findMany({
+    where: { tipoEquipo: 'router-nodo' },
+    include: { interfaces: true }
+  })
+
+  const serialized = devices.map(d => ({
+    ...d,
+    createdAt: d.createdAt.toISOString(),
+    interfaces: d.interfaces.map(i => ({ ...i, createdAt: i.createdAt.toISOString() }))
+  }))
+
+  return { props: { devices: serialized } }
+}


### PR DESCRIPTION
## Summary
- add new Aprovisionamiento menu in sidebar
- create Topologia page showing router-nodo devices and allowing interface-based connections

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c39fe5fc08322b43213b2ee97cf35