### PR TITLE
Add persistent topology connections

### DIFF
--- a/pages/api/connections/[id].ts
+++ b/pages/api/connections/[id].ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+
+  if (req.method === 'GET') {
+    const conn = await prisma.connection.findUnique({ where: { id } })
+    return res.status(200).json(conn)
+  }
+
+  if (req.method === 'PUT') {
+    const { srcDeviceId, srcInterface, dstDeviceId, dstInterface } = req.body
+    const conn = await prisma.connection.update({
+      where: { id },
+      data: {
+        srcDeviceId: Number(srcDeviceId),
+        srcInterface,
+        dstDeviceId: Number(dstDeviceId),
+        dstInterface
+      }
+    })
+    return res.status(200).json(conn)
+  }
+
+  if (req.method === 'DELETE') {
+    await prisma.connection.delete({ where: { id } })
+    return res.status(204).end()
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/connections/index.ts
+++ b/pages/api/connections/index.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const connections = await prisma.connection.findMany()
+    return res.status(200).json(connections)
+  }
+
+  if (req.method === 'POST') {
+    const { srcDeviceId, srcInterface, dstDeviceId, dstInterface } = req.body
+    const conn = await prisma.connection.create({
+      data: {
+        srcDeviceId: Number(srcDeviceId),
+        srcInterface,
+        dstDeviceId: Number(dstDeviceId),
+        dstInterface
+      }
+    })
+    return res.status(201).json(conn)
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/aprovisionamiento/topologia.tsx
+++ b/pages/aprovisionamiento/topologia.tsx
@@ -1,45 +1,91 @@
 import { GetServerSideProps } from 'next'
 import { getSession } from 'next-auth/react'
 import { useState } from 'react'
-import { Box, Heading, Select, Button, Flex } from '@chakra-ui/react'
+import { Box, Heading, Select, Button, Flex, Text } from '@chakra-ui/react'
 import SidebarLayout from '../../components/SidebarLayout'
 import { prisma } from '../../lib/prisma'
 
 type Interface = { id: number; name: string; description?: string | null }
 type Device = { id: number; ipGestion: string; hostname?: string | null; interfaces: Interface[] }
-
-export default function Topologia({ devices }: { devices: Device[] }) {
+type Connection = { id: number; srcDeviceId: number; srcInterface: string; dstDeviceId: number; dstInterface: string }
+export default function Topologia({ devices, initialConnections }: { devices: Device[]; initialConnections: Connection[] }) {
   const [srcId, setSrcId] = useState('')
   const [srcIf, setSrcIf] = useState('')
   const [dstId, setDstId] = useState('')
   const [dstIf, setDstIf] = useState('')
-  const [connections, setConnections] = useState<{ srcId: number; srcIf: string; dstId: number; dstIf: string }[]>([])
+  const [connections, setConnections] = useState<Connection[]>(initialConnections)
+  const [editId, setEditId] = useState<number | null>(null)
 
-  const positions = devices.map((_, idx) => ({ x: 100 + idx * 150, y: 100 }))
+  const positions = devices.map((_, idx) => ({ x: 120 + idx * 180, y: 120 }))
 
-  function handleAdd() {
+  async function handleAdd() {
     if (!srcId || !srcIf || !dstId || !dstIf) return
-    setConnections([...connections, { srcId: Number(srcId), srcIf, dstId: Number(dstId), dstIf }])
+    const payload = { srcDeviceId: Number(srcId), srcInterface: srcIf, dstDeviceId: Number(dstId), dstInterface: dstIf }
+    const res = await fetch('/api/connections', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    const data = await res.json()
+    setConnections([...connections, data])
+    setSrcId('')
+    setSrcIf('')
+    setDstId('')
+    setDstIf('')
+  }
+
+  async function handleUpdate(id: number) {
+    const payload = { srcDeviceId: Number(srcId), srcInterface: srcIf, dstDeviceId: Number(dstId), dstInterface: dstIf }
+    const res = await fetch(`/api/connections/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    const data = await res.json()
+    setConnections(connections.map(c => c.id === id ? data : c))
+    setEditId(null)
+    setSrcId('')
+    setSrcIf('')
+    setDstId('')
+    setDstIf('')
+  }
+
+  async function handleDelete(id: number) {
+    await fetch(`/api/connections/${id}`, { method: 'DELETE' })
+    setConnections(connections.filter(c => c.id !== id))
+  }
+
+  function startEdit(c: Connection) {
+    setEditId(c.id)
+    setSrcId(String(c.srcDeviceId))
+    setSrcIf(c.srcInterface)
+    setDstId(String(c.dstDeviceId))
+    setDstIf(c.dstInterface)
   }
 
   return (
     <SidebarLayout>
       <Box>
         <Heading size='md' mb={4}>Topolog\u00eda</Heading>
-        <svg width='100%' height='300' style={{ border: '1px solid #ccc' }}>
+        <svg width='100%' height='350' style={{ border: '1px solid #ccc' }}>
+          <defs>
+            <marker id='arrow' markerWidth='10' markerHeight='10' refX='8' refY='5' orient='auto-start-reverse'>
+              <path d='M0,0 L10,5 L0,10 z' fill='#4A5568' />
+            </marker>
+          </defs>
           {devices.map((d, i) => (
             <g key={d.id} transform={`translate(${positions[i].x}, ${positions[i].y})`}>
-              <circle r='20' fill='#90cdf4' />
-              <text x='-15' y='35' fontSize='10'>{d.hostname || d.ipGestion}</text>
+              <circle r='25' fill='#4299e1' />
+              <text x='-20' y='35' fontSize='12' fill='white'>{d.hostname || d.ipGestion}</text>
             </g>
           ))}
-          {connections.map((c, idx) => {
-            const si = devices.findIndex(d => d.id === c.srcId)
-            const di = devices.findIndex(d => d.id === c.dstId)
+          {connections.map((c) => {
+            const si = devices.findIndex(d => d.id === c.srcDeviceId)
+            const di = devices.findIndex(d => d.id === c.dstDeviceId)
             if (si === -1 || di === -1) return null
             const s = positions[si]
             const t = positions[di]
-            return <line key={idx} x1={s.x} y1={s.y} x2={t.x} y2={t.y} stroke='black' />
+            return <line key={c.id} x1={s.x} y1={s.y} x2={t.x} y2={t.y} stroke='#4A5568' strokeWidth={2} markerEnd='url(#arrow)' />
           })}
         </svg>
         <Flex mt={4} gap={2} flexWrap='wrap'>
@@ -63,8 +109,30 @@ export default function Topologia({ devices }: { devices: Device[] }) {
               <option key={i.id} value={i.name}>{i.name}</option>
             ))}
           </Select>
-          <Button onClick={handleAdd}>Conectar</Button>
+          {editId ? (
+            <>
+              <Button colorScheme='green' onClick={() => handleUpdate(editId!)}>Guardar</Button>
+              <Button onClick={() => { setEditId(null); setSrcId(''); setSrcIf(''); setDstId(''); setDstIf('') }}>Cancelar</Button>
+            </>
+          ) : (
+            <Button onClick={handleAdd}>Conectar</Button>
+          )}
         </Flex>
+        <Box mt={6}>
+          <Heading size='sm' mb={2}>Conexiones</Heading>
+          {connections.length === 0 && <Text>No hay conexiones</Text>}
+          {connections.map(c => (
+            <Flex key={c.id} align='center' mb={1}>
+              <Box flex='1'>
+                {devices.find(d => d.id === c.srcDeviceId)?.hostname || devices.find(d => d.id === c.srcDeviceId)?.ipGestion}:{' '}
+                {c.srcInterface} → {devices.find(d => d.id === c.dstDeviceId)?.hostname || devices.find(d => d.id === c.dstDeviceId)?.ipGestion}:{' '}
+                {c.dstInterface}
+              </Box>
+              <Button size='sm' mr={2} onClick={() => startEdit(c)}>Editar</Button>
+              <Button size='sm' colorScheme='red' onClick={() => handleDelete(c.id)}>Eliminar</Button>
+            </Flex>
+          ))}
+        </Box>
       </Box>
     </SidebarLayout>
   )
@@ -92,5 +160,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     interfaces: d.interfaces.map(i => ({ ...i, createdAt: i.createdAt.toISOString() }))
   }))
 
-  return { props: { devices: serialized } }
+  const connections = await prisma.connection.findMany()
+  const serializedConns = connections.map(c => ({
+    ...c,
+    createdAt: c.createdAt.toISOString()
+  }))
+
+  return { props: { devices: serialized, initialConnections: serializedConns } }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,8 @@ model Device {
   backups        Backup[]
   schedules      Schedule[]
   interfaces     Interface[]
+  srcConnections Connection[] @relation("SrcDeviceConnections")
+  dstConnections Connection[] @relation("DstDeviceConnections")
 }
 
 model Site {
@@ -89,4 +91,15 @@ model Interface {
   name        String
   description String?
   createdAt   DateTime @default(now())
+}
+
+model Connection {
+  id            Int      @id @default(autoincrement())
+  srcDeviceId   Int
+  srcInterface  String
+  dstDeviceId   Int
+  dstInterface  String
+  createdAt     DateTime @default(now())
+  srcDevice     Device   @relation("SrcDeviceConnections", fields: [srcDeviceId], references: [id])
+  dstDevice     Device   @relation("DstDeviceConnections", fields: [dstDeviceId], references: [id])
 }


### PR DESCRIPTION
## Summary
- add `Connection` model to prisma schema
- implement API endpoints to manage connections
- display and manage connections in the topology view

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module ...)*
- `npx prisma generate` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npx prisma format` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686c3db85f848322aa430bc974d352e1