### PR TITLE
Add manual backup feature and improve topology

### DIFF
--- a/pages/api/schedules/[id]/run.ts
+++ b/pages/api/schedules/[id]/run.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { runBackup } from '../../../../lib/scheduler'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+  if (req.method === 'POST') {
+    await runBackup(id)
+    return res.status(200).json({ ok: true })
+  }
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/schedules/index.ts
+++ b/pages/api/schedules/index.ts
@@ -10,9 +10,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   if (req.method === 'POST') {
-    const { deviceId, credentialId, period } = req.body
+    const { deviceId, period } = req.body
+    const device = await prisma.device.findUnique({ where: { id: Number(deviceId) } })
+    if (!device || !device.credentialId) {
+      return res.status(400).json({ message: 'Credencial no encontrada para el dispositivo' })
+    }
     const nextRun = new Date()
-    const sched = await prisma.schedule.create({ data: { deviceId: Number(deviceId), credentialId: Number(credentialId), period, nextRun } })
+    const sched = await prisma.schedule.create({ data: { deviceId: Number(deviceId), credentialId: device.credentialId, period, nextRun } })
     return res.status(201).json(sched)
   }
 

--- a/pages/aprovisionamiento/topologia.tsx
+++ b/pages/aprovisionamiento/topologia.tsx
@@ -26,17 +26,22 @@ export default function Topologia({ devices, initialConnections }: { devices: De
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
 
-  const edges: Edge[] = useMemo(
-    () =>
-      connections.map((c) => ({
+  const edges: Edge[] = useMemo(() => {
+    const count: Record<string, number> = {}
+    return connections.map((c) => {
+      const key = `${c.srcDeviceId}-${c.dstDeviceId}`
+      const idx = (count[key] = (count[key] || 0) + 1)
+      const offset = (idx - 1) * 15
+      return {
         id: String(c.id),
         source: String(c.srcDeviceId),
         target: String(c.dstDeviceId),
+        type: 'smoothstep',
         label: `${c.srcInterface} → ${c.dstInterface}`,
-        labelStyle: { fill: '#1a202c', fontWeight: 600, fontSize: 12 }
-      })),
-    [connections]
-  )
+        labelStyle: { fill: '#1a202c', fontWeight: 600, fontSize: 12, transform: `translateY(${offset}px)` }
+      }
+    })
+  }, [connections])
 
   async function handleAdd() {
     if (!srcId || !srcIf || !dstId || !dstIf) return

--- a/pages/backups/programacion/[id].tsx
+++ b/pages/backups/programacion/[id].tsx
@@ -1,0 +1,76 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Button, Input, Flex, Textarea } from '@chakra-ui/react'
+import SidebarLayout from '../../../components/SidebarLayout'
+import { prisma } from '../../../lib/prisma'
+
+interface Backup { id: number; content: string; createdAt: string }
+interface Schedule { id: number; device: { id: number; nombre: string } }
+
+export default function ScheduleDetail({ backups, schedule }: { backups: Backup[]; schedule: Schedule }) {
+  const router = useRouter()
+  const [filter, setFilter] = useState('')
+  const [sel, setSel] = useState<number[]>([])
+  const filtered = filter ? backups.filter(b => b.createdAt.startsWith(filter)) : backups
+  const compare = sel.length === 2 ?
+    filtered.find(b => b.id === sel[0])?.content.split('\n').map((l,i)=>({i,l}))
+      .map(({i,l})=> l === filtered.find(b=>b.id===sel[1])?.content.split('\n')[i] ? null : `${i+1}: ${l}`)
+      .filter(Boolean).join('\n') : ''
+
+  async function runNow() {
+    await fetch(`/api/schedules/${schedule.id}/run`, { method: 'POST' })
+    router.reload()
+  }
+
+  return (
+    <SidebarLayout>
+      <Flex mb={4} align='center'>
+        <Button mr={2} onClick={() => router.push('/backups/programacion')}>Volver</Button>
+        <Box as='h1' fontSize='xl' fontWeight='bold'>Programación de {schedule.device.nombre}</Box>
+      </Flex>
+      <Button colorScheme='blue' mb={4} onClick={runNow}>Sacar backup ahora</Button>
+      <Input type='date' mb={2} value={filter} onChange={e=>setFilter(e.target.value)} />
+      <Table variant='simple'>
+        <Thead>
+          <Tr>
+            <Th></Th>
+            <Th>Fecha</Th>
+            <Th>Contenido</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {filtered.map(b => (
+            <Tr key={b.id}>
+              <Td><input type='checkbox' onChange={e=>{
+                if(e.target.checked) setSel([...sel,b.id])
+                else setSel(sel.filter(id=>id!==b.id))
+              }} /></Td>
+              <Td>{new Date(b.createdAt).toLocaleString()}</Td>
+              <Td>{b.content}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      {compare && (
+        <Box mt={4}>
+          <Textarea value={compare} readOnly rows={10} />
+        </Box>
+      )}
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ params, ...context }) => {
+  const session = await getSession(context)
+  if (!session) {
+    return { redirect: { destination: '/login', permanent: false } }
+  }
+  const id = Number(params?.id)
+  const schedule = await prisma.schedule.findUnique({ where: { id }, include: { device: true } })
+  if (!schedule) return { notFound: true }
+  const backups = await prisma.backup.findMany({ where: { deviceId: schedule.deviceId }, orderBy: { createdAt: 'desc' } })
+  const serialized = backups.map(b => ({ ...b, createdAt: b.createdAt.toISOString() }))
+  return { props: { backups: serialized, schedule: { id: schedule.id, device: { id: schedule.device.id, nombre: schedule.device.nombre } } } }
+}


### PR DESCRIPTION
## Summary
- compute schedule credential from device and export `runBackup`
- add API endpoint to run schedule backups on demand
- tweak topology edges to show labels for multiple connections
- update scheduling UI and remove credential field
- add detail page with backup logs and manual run option

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c7b096d8083228b04f3fcfcb315b1