### PR TITLE
Add services management

### DIFF
--- a/components/SidebarLayout.tsx
+++ b/components/SidebarLayout.tsx
@@ -7,6 +7,7 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false)
   const [openBackups, setOpenBackups] = useState(false)
   const [openProv, setOpenProv] = useState(false)
+  const [openServ, setOpenServ] = useState(false)
   return (
     <Flex minH='100vh'>
       <Box w='220px' bg='gray.800' color='white' p={4} display='flex' flexDirection='column' justifyContent='space-between'>
@@ -103,6 +104,41 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
                 size='sm'
               >
                 Bodega
+              </Button>
+            </VStack>
+          </Collapse>
+          <Button
+            bg='white'
+            color='gray.800'
+            _hover={{ bg: 'gray.200' }}
+            w='100%'
+            onClick={() => setOpenServ(!openServ)}
+          >
+            Servicios
+          </Button>
+          <Collapse in={openServ} animateOpacity>
+            <VStack align='stretch' spacing={1} mt={1} pl={2}>
+              <Button
+                as={NextLink}
+                href='/servicios/clientes'
+                bg='white'
+                color='gray.800'
+                _hover={{ bg: 'gray.200' }}
+                w='100%'
+                size='sm'
+              >
+                Clientes
+              </Button>
+              <Button
+                as={NextLink}
+                href='/servicios/contratos'
+                bg='white'
+                color='gray.800'
+                _hover={{ bg: 'gray.200' }}
+                w='100%'
+                size='sm'
+              >
+                Contratos
               </Button>
             </VStack>
           </Collapse>

--- a/pages/api/clients/[id].ts
+++ b/pages/api/clients/[id].ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+
+  if (req.method === 'GET') {
+    const client = await prisma.client.findUnique({ where: { id } })
+    return res.status(200).json(client)
+  }
+
+  if (req.method === 'PUT') {
+    const data = req.body
+    const client = await prisma.client.update({ where: { id }, data })
+    return res.status(200).json(client)
+  }
+
+  if (req.method === 'DELETE') {
+    await prisma.client.delete({ where: { id } })
+    return res.status(204).end()
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/clients/index.ts
+++ b/pages/api/clients/index.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const clients = await prisma.client.findMany()
+    return res.status(200).json(clients)
+  }
+
+  if (req.method === 'POST') {
+    const { nombre, identificacion, razonSocial, nit } = req.body
+    const client = await prisma.client.create({ data: { nombre, identificacion, razonSocial, nit } })
+    return res.status(201).json(client)
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/contracts/[id].ts
+++ b/pages/api/contracts/[id].ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+
+  if (req.method === 'GET') {
+    const contract = await prisma.contract.findUnique({ where: { id }, include: { client: true } })
+    return res.status(200).json(contract)
+  }
+
+  if (req.method === 'PUT') {
+    const data = req.body
+    if (data.inicio) data.inicio = new Date(data.inicio)
+    if (data.fin) data.fin = new Date(data.fin)
+    const contract = await prisma.contract.update({ where: { id }, data })
+    return res.status(200).json(contract)
+  }
+
+  if (req.method === 'DELETE') {
+    await prisma.contract.delete({ where: { id } })
+    return res.status(204).end()
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/contracts/index.ts
+++ b/pages/api/contracts/index.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const contracts = await prisma.contract.findMany({ include: { client: true } })
+    return res.status(200).json(contracts)
+  }
+
+  if (req.method === 'POST') {
+    const { numero, clientId, descripcion, inicio, fin } = req.body
+    const data: any = { numero, clientId: Number(clientId), descripcion }
+    if (inicio) data.inicio = new Date(inicio)
+    if (fin) data.fin = new Date(fin)
+    const contract = await prisma.contract.create({ data })
+    return res.status(201).json(contract)
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/backups/bodega/[id].tsx
+++ b/pages/backups/bodega/[id].tsx
@@ -1,7 +1,8 @@
 import { GetServerSideProps } from 'next'
 import { getSession } from 'next-auth/react'
 import { useRouter } from 'next/router'
-import { Box, Table, Thead, Tbody, Tr, Th, Td, Button } from '@chakra-ui/react'
+import { useState } from 'react'
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Button, Input } from '@chakra-ui/react'
 import SidebarLayout from '../../../components/SidebarLayout'
 import { prisma } from '../../../lib/prisma'
 
@@ -10,11 +11,24 @@ interface Device { id: number; nombre: string }
 
 export default function Backups({ backups, device }: { backups: Backup[]; device: Device }) {
   const router = useRouter()
+  const [search, setSearch] = useState('')
+  const filtered = backups.filter(b =>
+    b.content.toLowerCase().includes(search.toLowerCase())
+  )
   return (
     <SidebarLayout>
       <Box display='flex' alignItems='center' mb={4}>
         <Button mr={2} onClick={() => router.push('/backups/bodega')}>Volver</Button>
         <Box as='h1' fontSize='xl' fontWeight='bold'>Backups de {device.nombre}</Box>
+        <Input
+          placeholder='Buscar...'
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          ml={2}
+          bg='white'
+          color='black'
+          w='200px'
+        />
       </Box>
       <Table variant='simple'>
         <Thead>
@@ -24,7 +38,7 @@ export default function Backups({ backups, device }: { backups: Backup[]; device
           </Tr>
         </Thead>
         <Tbody>
-          {backups.map(b => (
+          {filtered.map(b => (
             <Tr key={b.id}>
               <Td>{new Date(b.createdAt).toLocaleString()}</Td>
               <Td>{b.content}</Td>

--- a/pages/backups/bodega/index.tsx
+++ b/pages/backups/bodega/index.tsx
@@ -1,7 +1,8 @@
 import { GetServerSideProps } from 'next'
 import { getSession } from 'next-auth/react'
 import { useRouter } from 'next/router'
-import { Box, Table, Thead, Tbody, Tr, Th, Td, Button } from '@chakra-ui/react'
+import { useState } from 'react'
+import { Box, Table, Thead, Tbody, Tr, Th, Td, Button, Input } from '@chakra-ui/react'
 import SidebarLayout from '../../../components/SidebarLayout'
 import { prisma } from '../../../lib/prisma'
 
@@ -9,9 +10,23 @@ interface Device { id: number; nombre: string }
 
 export default function Bodega({ devices }: { devices: Device[] }) {
   const router = useRouter()
+  const [search, setSearch] = useState('')
+  const filtered = devices.filter(d =>
+    d.nombre.toLowerCase().includes(search.toLowerCase())
+  )
   return (
     <SidebarLayout>
-      <Box as='h1' fontSize='xl' fontWeight='bold' mb={4}>Bodega Backups</Box>
+      <Box display='flex' justifyContent='space-between' alignItems='center' mb={4}>
+        <Box as='h1' fontSize='xl' fontWeight='bold'>Bodega Backups</Box>
+        <Input
+          placeholder='Buscar...'
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          w='200px'
+          bg='white'
+          color='black'
+        />
+      </Box>
       <Table variant='simple'>
         <Thead>
           <Tr>
@@ -20,7 +35,7 @@ export default function Bodega({ devices }: { devices: Device[] }) {
           </Tr>
         </Thead>
         <Tbody>
-          {devices.map(d => (
+          {filtered.map(d => (
             <Tr key={d.id}>
               <Td>{d.nombre}</Td>
               <Td>

--- a/pages/backups/programacion.tsx
+++ b/pages/backups/programacion.tsx
@@ -18,6 +18,7 @@ export default function Programacion({ devices, schedules }: { devices: Device[]
   const router = useRouter()
   const [form, setForm] = useState({ deviceId: '', period: 'DAILY' })
   const [isOpen, setIsOpen] = useState(false)
+  const [search, setSearch] = useState('')
   const onClose = () => setIsOpen(false)
 
   function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
@@ -34,11 +35,25 @@ export default function Programacion({ devices, schedules }: { devices: Device[]
     router.reload()
   }
 
+  const filtered = schedules.filter(s =>
+    s.device.nombre.toLowerCase().includes(search.toLowerCase())
+  )
+
   return (
     <SidebarLayout>
       <Box display='flex' justifyContent='space-between' alignItems='center' mb={4}>
         <Box as='h1' fontSize='xl' fontWeight='bold'>Programación de Backups</Box>
-        <Button colorScheme='blue' onClick={() => setIsOpen(true)}>Agregar</Button>
+        <Box ml='auto' display='flex' alignItems='center'>
+          <Input
+            placeholder='Buscar...'
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            mr={2}
+            bg='white'
+            color='black'
+          />
+          <Button colorScheme='blue' onClick={() => setIsOpen(true)}>Agregar</Button>
+        </Box>
       </Box>
 
       <Drawer isOpen={isOpen} placement='right' onClose={onClose} size='md'>
@@ -80,7 +95,7 @@ export default function Programacion({ devices, schedules }: { devices: Device[]
           </Tr>
         </Thead>
         <Tbody>
-          {schedules.map(s => (
+          {filtered.map(s => (
             <Tr key={s.id}>
               <Td>{s.device.nombre}</Td>
               <Td>{s.credential.usuario}</Td>

--- a/pages/passwords/index.tsx
+++ b/pages/passwords/index.tsx
@@ -34,6 +34,7 @@ export default function Passwords({ credentials }: { credentials: Credential[] }
   const router = useRouter()
   const [form, setForm] = useState({ usuario: '', contrasena: '' })
   const [isOpen, setIsOpen] = useState(false)
+  const [search, setSearch] = useState('')
   const onClose = () => setIsOpen(false)
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -56,11 +57,25 @@ export default function Passwords({ credentials }: { credentials: Credential[] }
     router.reload()
   }
 
+  const filtered = credentials.filter(c =>
+    c.usuario.toLowerCase().includes(search.toLowerCase())
+  )
+
   return (
     <SidebarLayout>
       <Box display='flex' justifyContent='space-between' alignItems='center' mb={4}>
         <Box as='h1' fontSize='xl' fontWeight='bold'>Contraseñas</Box>
-        <Button colorScheme='blue' onClick={() => setIsOpen(true)}>Agregar</Button>
+        <Box ml='auto' display='flex' alignItems='center'>
+          <Input
+            placeholder='Buscar...'
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            mr={2}
+            bg='white'
+            color='black'
+          />
+          <Button colorScheme='blue' onClick={() => setIsOpen(true)}>Agregar</Button>
+        </Box>
       </Box>
 
       <Drawer isOpen={isOpen} placement='right' onClose={onClose} size='md'>
@@ -93,7 +108,7 @@ export default function Passwords({ credentials }: { credentials: Credential[] }
           </Tr>
         </Thead>
         <Tbody>
-          {credentials.map((c) => (
+          {filtered.map((c) => (
             <Tr key={c.id}>
               <Td>{c.usuario}</Td>
               <Td>******</Td>

--- a/pages/servicios/clientes/[id].tsx
+++ b/pages/servicios/clientes/[id].tsx
@@ -1,0 +1,70 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { Box, Button, FormControl, FormLabel, Heading, Input } from '@chakra-ui/react'
+import SidebarLayout from '../../../components/SidebarLayout'
+import { prisma } from '../../../lib/prisma'
+
+interface Client {
+  id: number
+  nombre: string
+  identificacion: string
+  razonSocial: string
+  nit: string
+}
+
+export default function EditClient({ client }: { client: Client }) {
+  const router = useRouter()
+  const [form, setForm] = useState({ ...client })
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  async function handleSave() {
+    await fetch(`/api/clients/${client.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    router.push('/servicios/clientes')
+  }
+
+  return (
+    <SidebarLayout>
+      <Box maxW='md' mx='auto'>
+        <Heading size='md' mb={4}>Editar Cliente</Heading>
+        <FormControl mb={2}>
+          <FormLabel>Nombre</FormLabel>
+          <Input name='nombre' value={form.nombre} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Identificación</FormLabel>
+          <Input name='identificacion' value={form.identificacion} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Razón Social</FormLabel>
+          <Input name='razonSocial' value={form.razonSocial} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>NIT</FormLabel>
+          <Input name='nit' value={form.nit} onChange={handleChange} />
+        </FormControl>
+        <Button onClick={handleSave} colorScheme='blue'>Guardar</Button>
+      </Box>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ params, ...context }) => {
+  const session = await getSession(context)
+  if (!session) {
+    return { redirect: { destination: '/login', permanent: false } }
+  }
+  const id = Number(params?.id)
+  const client = await prisma.client.findUnique({ where: { id } })
+  if (!client) return { notFound: true }
+  const serialized = { ...client, createdAt: client.createdAt.toISOString() }
+  return { props: { client: serialized } }
+}

--- a/pages/servicios/clientes/index.tsx
+++ b/pages/servicios/clientes/index.tsx
@@ -21,19 +21,20 @@ import {
   Thead,
   Tr
 } from '@chakra-ui/react'
-import SidebarLayout from '../../components/SidebarLayout'
-import { prisma } from '../../lib/prisma'
+import SidebarLayout from '../../../components/SidebarLayout'
+import { prisma } from '../../../lib/prisma'
 
-interface Site {
+interface Client {
   id: number
-  name: string
-  ubicacion?: string | null
-  descripcion?: string | null
+  nombre: string
+  identificacion: string
+  razonSocial: string
+  nit: string
 }
 
-export default function Sites({ sites }: { sites: Site[] }) {
+export default function Clients({ clients }: { clients: Client[] }) {
   const router = useRouter()
-  const [form, setForm] = useState({ name: '', ubicacion: '', descripcion: '' })
+  const [form, setForm] = useState({ nombre: '', identificacion: '', razonSocial: '', nit: '' })
   const [isOpen, setIsOpen] = useState(false)
   const [search, setSearch] = useState('')
   const onClose = () => setIsOpen(false)
@@ -43,30 +44,30 @@ export default function Sites({ sites }: { sites: Site[] }) {
   }
 
   async function handleAdd() {
-    await fetch('/api/sites', {
+    await fetch('/api/clients', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(form)
     })
-    setForm({ name: '', ubicacion: '', descripcion: '' })
+    setForm({ nombre: '', identificacion: '', razonSocial: '', nit: '' })
     onClose()
     router.reload()
   }
 
   async function handleDelete(id: number) {
-    await fetch(`/api/sites/${id}`, { method: 'DELETE' })
+    await fetch(`/api/clients/${id}`, { method: 'DELETE' })
     router.reload()
   }
 
-  const filtered = sites.filter(s =>
-    s.name.toLowerCase().includes(search.toLowerCase()) ||
-    (s.ubicacion || '').toLowerCase().includes(search.toLowerCase())
+  const filtered = clients.filter(c =>
+    c.nombre.toLowerCase().includes(search.toLowerCase()) ||
+    c.identificacion.toLowerCase().includes(search.toLowerCase())
   )
 
   return (
     <SidebarLayout>
       <Box display='flex' justifyContent='space-between' alignItems='center' mb={4}>
-        <Box as='h1' fontSize='xl' fontWeight='bold'>Sitios</Box>
+        <Box as='h1' fontSize='xl' fontWeight='bold'>Clientes</Box>
         <Box ml='auto' display='flex' alignItems='center'>
           <Input
             placeholder='Buscar...'
@@ -83,19 +84,23 @@ export default function Sites({ sites }: { sites: Site[] }) {
       <Drawer isOpen={isOpen} placement='right' onClose={onClose} size='md'>
         <DrawerOverlay />
         <DrawerContent>
-          <DrawerHeader>Agregar Sitio</DrawerHeader>
+          <DrawerHeader>Agregar Cliente</DrawerHeader>
           <DrawerBody>
             <FormControl mb={2}>
               <FormLabel>Nombre</FormLabel>
-              <Input name='name' value={form.name} onChange={handleChange} />
+              <Input name='nombre' value={form.nombre} onChange={handleChange} />
             </FormControl>
             <FormControl mb={2}>
-              <FormLabel>Ubicación</FormLabel>
-              <Input name='ubicacion' value={form.ubicacion} onChange={handleChange} />
+              <FormLabel>Identificación</FormLabel>
+              <Input name='identificacion' value={form.identificacion} onChange={handleChange} />
             </FormControl>
             <FormControl mb={2}>
-              <FormLabel>Descripción</FormLabel>
-              <Input name='descripcion' value={form.descripcion} onChange={handleChange} />
+              <FormLabel>Razón Social</FormLabel>
+              <Input name='razonSocial' value={form.razonSocial} onChange={handleChange} />
+            </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>NIT</FormLabel>
+              <Input name='nit' value={form.nit} onChange={handleChange} />
             </FormControl>
           </DrawerBody>
           <DrawerFooter>
@@ -109,20 +114,22 @@ export default function Sites({ sites }: { sites: Site[] }) {
         <Thead>
           <Tr>
             <Th>Nombre</Th>
-            <Th>Ubicación</Th>
-            <Th>Descripción</Th>
+            <Th>Identificación</Th>
+            <Th>Razón Social</Th>
+            <Th>NIT</Th>
             <Th>Acciones</Th>
           </Tr>
         </Thead>
         <Tbody>
-          {filtered.map((s) => (
-            <Tr key={s.id}>
-              <Td>{s.name}</Td>
-              <Td>{s.ubicacion}</Td>
-              <Td>{s.descripcion}</Td>
+          {filtered.map(c => (
+            <Tr key={c.id}>
+              <Td>{c.nombre}</Td>
+              <Td>{c.identificacion}</Td>
+              <Td>{c.razonSocial}</Td>
+              <Td>{c.nit}</Td>
               <Td>
-                <Button size='sm' mr={2} onClick={() => router.push(`/sites/${s.id}`)}>Editar</Button>
-                <Button size='sm' colorScheme='red' onClick={() => handleDelete(s.id)}>Eliminar</Button>
+                <Button size='sm' mr={2} onClick={() => router.push(`/servicios/clientes/${c.id}`)}>Editar</Button>
+                <Button size='sm' colorScheme='red' onClick={() => handleDelete(c.id)}>Eliminar</Button>
               </Td>
             </Tr>
           ))}
@@ -135,15 +142,9 @@ export default function Sites({ sites }: { sites: Site[] }) {
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getSession(context)
   if (!session) {
-    return {
-      redirect: {
-        destination: '/login',
-        permanent: false
-      }
-    }
+    return { redirect: { destination: '/login', permanent: false } }
   }
-
-  const sites = await prisma.site.findMany()
-  const serializedSites = sites.map((s) => ({ ...s, createdAt: s.createdAt.toISOString() }))
-  return { props: { sites: serializedSites } }
+  const clients = await prisma.client.findMany()
+  const serialized = clients.map(c => ({ ...c, createdAt: c.createdAt.toISOString() }))
+  return { props: { clients: serialized } }
 }

--- a/pages/servicios/contratos/[id].tsx
+++ b/pages/servicios/contratos/[id].tsx
@@ -1,0 +1,79 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { Box, Button, FormControl, FormLabel, Heading, Input, Select } from '@chakra-ui/react'
+import SidebarLayout from '../../../components/SidebarLayout'
+import { prisma } from '../../../lib/prisma'
+
+interface Client { id: number; nombre: string }
+interface Contract {
+  id: number
+  numero: string
+  descripcion?: string | null
+  inicio?: string | null
+  fin?: string | null
+  clientId: number
+}
+
+export default function EditContract({ contract, clients }: { contract: Contract; clients: Client[] }) {
+  const router = useRouter()
+  const [form, setForm] = useState({ ...contract, inicio: contract.inicio || '', fin: contract.fin || '' })
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  async function handleSave() {
+    await fetch(`/api/contracts/${contract.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...form, clientId: Number(form.clientId) })
+    })
+    router.push('/servicios/contratos')
+  }
+
+  return (
+    <SidebarLayout>
+      <Box maxW='md' mx='auto'>
+        <Heading size='md' mb={4}>Editar Contrato</Heading>
+        <FormControl mb={2}>
+          <FormLabel>Número</FormLabel>
+          <Input name='numero' value={form.numero} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Cliente</FormLabel>
+          <Select name='clientId' value={form.clientId} onChange={handleChange}>
+            {clients.map(c => <option key={c.id} value={c.id}>{c.nombre}</option>)}
+          </Select>
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Descripción</FormLabel>
+          <Input name='descripcion' value={form.descripcion || ''} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Inicio</FormLabel>
+          <Input type='date' name='inicio' value={form.inicio as string} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Fin</FormLabel>
+          <Input type='date' name='fin' value={form.fin as string} onChange={handleChange} />
+        </FormControl>
+        <Button onClick={handleSave} colorScheme='blue'>Guardar</Button>
+      </Box>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ params, ...context }) => {
+  const session = await getSession(context)
+  if (!session) {
+    return { redirect: { destination: '/login', permanent: false } }
+  }
+  const id = Number(params?.id)
+  const contract = await prisma.contract.findUnique({ where: { id } })
+  if (!contract) return { notFound: true }
+  const clients = await prisma.client.findMany({ select: { id: true, nombre: true } })
+  const serialized = { ...contract, inicio: contract.inicio ? contract.inicio.toISOString().substring(0,10) : '', fin: contract.fin ? contract.fin.toISOString().substring(0,10) : '', createdAt: contract.createdAt.toISOString() }
+  return { props: { contract: serialized, clients } }
+}

--- a/pages/servicios/contratos/index.tsx
+++ b/pages/servicios/contratos/index.tsx
@@ -1,0 +1,161 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState, useEffect } from 'react'
+import {
+  Box,
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr
+} from '@chakra-ui/react'
+import SidebarLayout from '../../../components/SidebarLayout'
+import { prisma } from '../../../lib/prisma'
+
+interface Client { id: number; nombre: string }
+interface Contract {
+  id: number
+  numero: string
+  descripcion?: string | null
+  inicio?: string | null
+  fin?: string | null
+  client: Client
+}
+
+export default function Contracts({ contracts, clients }: { contracts: Contract[]; clients: Client[] }) {
+  const router = useRouter()
+  const [form, setForm] = useState({ numero: '', descripcion: '', inicio: '', fin: '', clientId: '' })
+  const [isOpen, setIsOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const onClose = () => setIsOpen(false)
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  async function handleAdd() {
+    await fetch('/api/contracts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...form, clientId: Number(form.clientId) })
+    })
+    setForm({ numero: '', descripcion: '', inicio: '', fin: '', clientId: '' })
+    onClose()
+    router.reload()
+  }
+
+  async function handleDelete(id: number) {
+    await fetch(`/api/contracts/${id}`, { method: 'DELETE' })
+    router.reload()
+  }
+
+  const filtered = contracts.filter(c =>
+    c.numero.toLowerCase().includes(search.toLowerCase()) ||
+    c.client.nombre.toLowerCase().includes(search.toLowerCase())
+  )
+
+  return (
+    <SidebarLayout>
+      <Box display='flex' justifyContent='space-between' alignItems='center' mb={4}>
+        <Box as='h1' fontSize='xl' fontWeight='bold'>Contratos</Box>
+        <Box ml='auto' display='flex' alignItems='center'>
+          <Input
+            placeholder='Buscar...'
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            mr={2}
+            bg='white'
+            color='black'
+          />
+          <Button colorScheme='blue' onClick={() => setIsOpen(true)}>Agregar</Button>
+        </Box>
+      </Box>
+
+      <Drawer isOpen={isOpen} placement='right' onClose={onClose} size='md'>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerHeader>Agregar Contrato</DrawerHeader>
+          <DrawerBody>
+            <FormControl mb={2}>
+              <FormLabel>Número</FormLabel>
+              <Input name='numero' value={form.numero} onChange={handleChange} />
+            </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Cliente</FormLabel>
+              <Select name='clientId' value={form.clientId} onChange={handleChange}>
+                <option value=''>Seleccione...</option>
+                {clients.map(c => <option key={c.id} value={c.id}>{c.nombre}</option>)}
+              </Select>
+            </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Descripción</FormLabel>
+              <Input name='descripcion' value={form.descripcion} onChange={handleChange} />
+            </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Inicio</FormLabel>
+              <Input type='date' name='inicio' value={form.inicio} onChange={handleChange} />
+            </FormControl>
+            <FormControl mb={2}>
+              <FormLabel>Fin</FormLabel>
+              <Input type='date' name='fin' value={form.fin} onChange={handleChange} />
+            </FormControl>
+          </DrawerBody>
+          <DrawerFooter>
+            <Button variant='outline' mr={3} onClick={onClose}>Cancelar</Button>
+            <Button colorScheme='blue' onClick={handleAdd}>Guardar</Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+
+      <Table variant='simple'>
+        <Thead>
+          <Tr>
+            <Th>Número</Th>
+            <Th>Cliente</Th>
+            <Th>Inicio</Th>
+            <Th>Fin</Th>
+            <Th>Acciones</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {filtered.map(c => (
+            <Tr key={c.id}>
+              <Td>{c.numero}</Td>
+              <Td>{c.client.nombre}</Td>
+              <Td>{c.inicio ? new Date(c.inicio).toLocaleDateString() : ''}</Td>
+              <Td>{c.fin ? new Date(c.fin).toLocaleDateString() : ''}</Td>
+              <Td>
+                <Button size='sm' mr={2} onClick={() => router.push(`/servicios/contratos/${c.id}`)}>Editar</Button>
+                <Button size='sm' colorScheme='red' onClick={() => handleDelete(c.id)}>Eliminar</Button>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context)
+  if (!session) {
+    return { redirect: { destination: '/login', permanent: false } }
+  }
+  const contracts = await prisma.contract.findMany({ include: { client: true } })
+  const clients = await prisma.client.findMany({ select: { id: true, nombre: true } })
+  const serialized = contracts.map(c => ({ ...c, inicio: c.inicio ? c.inicio.toISOString() : null, fin: c.fin ? c.fin.toISOString() : null, createdAt: c.createdAt.toISOString() }))
+  return { props: { contracts: serialized, clients } }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,3 +103,24 @@ model Connection {
   srcDevice     Device   @relation("SrcDeviceConnections", fields: [srcDeviceId], references: [id])
   dstDevice     Device   @relation("DstDeviceConnections", fields: [dstDeviceId], references: [id])
 }
+
+model Client {
+  id             Int       @id @default(autoincrement())
+  nombre         String
+  identificacion String
+  razonSocial    String
+  nit            String
+  contratos      Contract[]
+  createdAt      DateTime  @default(now())
+}
+
+model Contract {
+  id          Int      @id @default(autoincrement())
+  numero      String
+  descripcion String?
+  inicio      DateTime?
+  fin         DateTime?
+  client      Client   @relation(fields: [clientId], references: [id])
+  clientId    Int
+  createdAt   DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- manage clients and contracts in new Servicios menu
- create Prisma models for Client and Contract
- add API routes for clients and contracts
- enhance existing forms with search bars
- improve sidebar navigation

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687c1c0ba0c483228c70a933e770156d