### PR TITLE
Add software compliance tracking with golden images

### DIFF
--- a/components/SidebarLayout.tsx
+++ b/components/SidebarLayout.tsx
@@ -70,6 +70,17 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
               >
                 Contraseñas
               </Button>
+              <Button
+                as={NextLink}
+                href='/software/cumplimiento'
+                bg='white'
+                color='gray.800'
+                _hover={{ bg: 'gray.200' }}
+                w='100%'
+                size='sm'
+              >
+                Cumplimiento de Software
+              </Button>
             </VStack>
           </Collapse>
           <Button

--- a/pages/api/devices/[id]/apply-golden.ts
+++ b/pages/api/devices/[id]/apply-golden.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../../lib/prisma'
+import { Client } from 'ssh2'
+import { exec } from 'child_process'
+import fs from 'fs/promises'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+  if (req.method !== 'POST') {
+    res.status(405).json({ message: 'Method not allowed' })
+    return
+  }
+  const device = await prisma.device.findUnique({ where: { id }, include: { credential: true } })
+  if (!device || !device.boardName) {
+    res.status(404).json({ message: 'Device not found' })
+    return
+  }
+  const golden = await prisma.goldenImage.findFirst({ where: { modelo: device.boardName } })
+  if (!golden) {
+    res.status(404).json({ message: 'Golden image not found' })
+    return
+  }
+  const tmp = `/tmp/${Date.now()}-golden.rsc`
+  await fs.writeFile(tmp, golden.config)
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const conn = new Client()
+      conn.on('ready', () => {
+        conn.exec('ip service set ftp disabled=no', (err, stream) => {
+          if (err) { conn.end(); return reject(err) }
+          stream.on('close', () => { conn.end(); resolve() })
+        })
+      }).on('error', reject).connect({
+        host: device.ipGestion,
+        username: device.credential?.usuario || process.env.MIKROTIK_USER || 'admin',
+        password: device.credential?.contrasena || process.env.MIKROTIK_PASS || '',
+        readyTimeout: 5000
+      })
+    })
+    await new Promise<void>((resolve) => {
+      exec(`curl -T ${tmp} ftp://admin:R3d3s2025%21%21%2B%2B@${device.ipGestion}/`, () => resolve())
+    })
+  } finally {
+    await fs.unlink(tmp).catch(() => {})
+  }
+  res.status(200).json({ ok: true })
+}

--- a/pages/api/golden-images/[id].ts
+++ b/pages/api/golden-images/[id].ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+
+  if (req.method === 'GET') {
+    const image = await prisma.goldenImage.findUnique({ where: { id } })
+    return res.status(200).json(image)
+  }
+
+  if (req.method === 'PUT') {
+    const data = req.body
+    const image = await prisma.goldenImage.update({ where: { id }, data })
+    return res.status(200).json(image)
+  }
+
+  if (req.method === 'DELETE') {
+    await prisma.goldenImage.delete({ where: { id } })
+    return res.status(204).end()
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/api/golden-images/index.ts
+++ b/pages/api/golden-images/index.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const images = await prisma.goldenImage.findMany()
+    return res.status(200).json(images)
+  }
+
+  if (req.method === 'POST') {
+    const { modelo, version, config } = req.body
+    const image = await prisma.goldenImage.create({ data: { modelo, version, config } })
+    return res.status(201).json(image)
+  }
+
+  res.status(405).json({ message: 'Method not allowed' })
+}

--- a/pages/software/cumplimiento.tsx
+++ b/pages/software/cumplimiento.tsx
@@ -1,0 +1,98 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { Box, Button, Table, Thead, Tbody, Tr, Th, Td } from '@chakra-ui/react'
+import SidebarLayout from '../../components/SidebarLayout'
+import { prisma } from '../../lib/prisma'
+
+interface Device {
+  id: number
+  ipGestion: string
+  marca: string
+  boardName?: string | null
+  versionSoftware?: string | null
+}
+
+interface GoldenImage {
+  id: number
+  modelo: string
+  version: string
+}
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0)
+    if (diff !== 0) return diff
+  }
+  return 0
+}
+
+export default function Cumplimiento({ devices, images }: { devices: Device[]; images: GoldenImage[] }) {
+  const router = useRouter()
+  const [loading, setLoading] = useState<number | null>(null)
+
+  async function handleUpdate(id: number) {
+    setLoading(id)
+    await fetch(`/api/devices/${id}/apply-golden`, { method: 'POST' })
+    setLoading(null)
+    router.reload()
+  }
+
+  return (
+    <SidebarLayout>
+      <Box display='flex' justifyContent='space-between' alignItems='center' mb={4}>
+        <Box as='h1' fontSize='xl' fontWeight='bold'>Cumplimiento de Software</Box>
+        <Button colorScheme='blue' onClick={() => router.push('/software/golden')}>Golden Images</Button>
+      </Box>
+      <Table variant='simple'>
+        <Thead>
+          <Tr>
+            <Th>IP</Th>
+            <Th>Marca</Th>
+            <Th>Modelo</Th>
+            <Th>Versión</Th>
+            <Th>Golden</Th>
+            <Th>Estado</Th>
+            <Th>Acciones</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {devices.map(d => {
+            const img = images.find(g => g.modelo === d.boardName)
+            const status = img && d.versionSoftware ? (compareVersions(d.versionSoftware, img.version) >= 0 ? 'Cumple' : 'Sin cumplimiento') : 'Sin golden'
+            return (
+              <Tr key={d.id}>
+                <Td>{d.ipGestion}</Td>
+                <Td>{d.marca}</Td>
+                <Td>{d.boardName}</Td>
+                <Td>{d.versionSoftware}</Td>
+                <Td>{img?.version || '-'}</Td>
+                <Td>{status}</Td>
+                <Td>
+                  {status === 'Sin cumplimiento' && (
+                    <Button size='sm' onClick={() => handleUpdate(d.id)} isLoading={loading === d.id}>Actualizar</Button>
+                  )}
+                </Td>
+              </Tr>
+            )
+          })}
+        </Tbody>
+      </Table>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context)
+  if (!session) {
+    return { redirect: { destination: '/login', permanent: false } }
+  }
+  const devices = await prisma.device.findMany({ select: { id: true, ipGestion: true, marca: true, boardName: true, versionSoftware: true } })
+  const images = await prisma.goldenImage.findMany()
+  const serializedDevices = devices.map(d => ({ ...d }))
+  const serializedImages = images.map(i => ({ ...i }))
+  return { props: { devices: serializedDevices, images: serializedImages } }
+}

--- a/pages/software/golden.tsx
+++ b/pages/software/golden.tsx
@@ -1,0 +1,96 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState, useEffect } from 'react'
+import { Box, Button, FormControl, FormLabel, Input, Table, Thead, Tbody, Tr, Th, Td } from '@chakra-ui/react'
+import SidebarLayout from '../../components/SidebarLayout'
+import { prisma } from '../../lib/prisma'
+
+interface GoldenImage {
+  id: number
+  modelo: string
+  version: string
+}
+
+export default function Golden({ models, images }: { models: string[]; images: GoldenImage[] }) {
+  const router = useRouter()
+  const [form, setForm] = useState({ modelo: '', version: '', config: '' })
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = (ev) => {
+      setForm(f => ({ ...f, config: ev.target?.result as string || '' }))
+    }
+    reader.readAsText(file)
+  }
+
+  async function handleAdd() {
+    await fetch('/api/golden-images', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form)
+    })
+    setForm({ modelo: '', version: '', config: '' })
+    router.reload()
+  }
+
+  return (
+    <SidebarLayout>
+      <Box mb={4} display='flex' justifyContent='space-between' alignItems='center'>
+        <Button onClick={() => router.push('/software/cumplimiento')} mr={2}>Volver</Button>
+        <Box as='h1' fontSize='xl' fontWeight='bold'>Golden Images</Box>
+      </Box>
+      <Box maxW='md' mb={4} bg='white' p={4} borderRadius='md'>
+        <FormControl mb={2}>
+          <FormLabel>Modelo</FormLabel>
+          <select name='modelo' value={form.modelo} onChange={handleChange} style={{ width: '100%', padding: '8px', borderRadius: '4px' }}>
+            <option value=''>Seleccione...</option>
+            {models.map(m => <option key={m} value={m}>{m}</option>)}
+          </select>
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Versión</FormLabel>
+          <Input name='version' value={form.version} onChange={handleChange} />
+        </FormControl>
+        <FormControl mb={2}>
+          <FormLabel>Archivo de configuración</FormLabel>
+          <Input type='file' onChange={handleFile} />
+        </FormControl>
+        <Button colorScheme='blue' onClick={handleAdd}>Guardar</Button>
+      </Box>
+      <Table variant='simple'>
+        <Thead>
+          <Tr>
+            <Th>Modelo</Th>
+            <Th>Versión</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {images.map(i => (
+            <Tr key={i.id}>
+              <Td>{i.modelo}</Td>
+              <Td>{i.version}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </SidebarLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const session = await getSession(context)
+  if (!session) {
+    return { redirect: { destination: '/login', permanent: false } }
+  }
+  const modelsRes = await prisma.device.findMany({ where: { boardName: { not: null } }, distinct: ['boardName'], select: { boardName: true } })
+  const models = modelsRes.map(m => m.boardName!).filter(Boolean)
+  const images = await prisma.goldenImage.findMany()
+  return { props: { models, images } }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,3 +124,11 @@ model Contract {
   clientId    Int
   createdAt   DateTime @default(now())
 }
+
+model GoldenImage {
+  id        Int      @id @default(autoincrement())
+  modelo    String
+  version   String
+  config    String
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- define `GoldenImage` model in Prisma schema
- create API routes to manage golden images
- create API route to apply a golden image to a device via FTP
- add pages to manage golden images and view compliance
- link new compliance view in sidebar

## Testing
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c5ec259f483229db5b3f8ec7cbce0