### PR TITLE
Fix golden image upload

### DIFF
--- a/pages/api/golden-images/index.ts
+++ b/pages/api/golden-images/index.ts
@@ -1,6 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { prisma } from '../../../lib/prisma'
 
+export const config = {
+  api: { bodyParser: { sizeLimit: '10mb' } }
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     const images = await prisma.goldenImage.findMany()

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,6 +129,6 @@ model GoldenImage {
   id        Int      @id @default(autoincrement())
   modelo    String
   version   String
-  config    String
+  config    String   @db.LongText
   createdAt DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- allow larger golden image uploads
- store golden image configuration as a long text field

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687c63007e1c83229cf68adde9bcbfd1