### PR TITLE
Fix Next.js date serialization error

### DIFF
--- a/pages/software/cumplimiento.tsx
+++ b/pages/software/cumplimiento.tsx
@@ -93,6 +93,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const devices = await prisma.device.findMany({ select: { id: true, ipGestion: true, marca: true, boardName: true, versionSoftware: true } })
   const images = await prisma.goldenImage.findMany()
   const serializedDevices = devices.map(d => ({ ...d }))
-  const serializedImages = images.map(i => ({ ...i }))
+  const serializedImages = images.map(i => ({
+    ...i,
+    createdAt: i.createdAt.toISOString(),
+  }))
   return { props: { devices: serializedDevices, images: serializedImages } }
 }

--- a/pages/software/golden.tsx
+++ b/pages/software/golden.tsx
@@ -92,5 +92,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const modelsRes = await prisma.device.findMany({ where: { boardName: { not: null } }, distinct: ['boardName'], select: { boardName: true } })
   const models = modelsRes.map(m => m.boardName!).filter(Boolean)
   const images = await prisma.goldenImage.findMany()
-  return { props: { models, images } }
+  const serializedImages = images.map(img => ({
+    ...img,
+    createdAt: img.createdAt.toISOString(),
+  }))
+  return { props: { models, images: serializedImages } }
 }


### PR DESCRIPTION
## Summary
- convert `createdAt` Date objects to ISO strings in `golden` page
- apply same conversion in software compliance page

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c682010b883228ade3c1cd70632f9