### PR TITLE
Add default admin user seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-"# SDN" 
+# SDN
+
+Usuario administrador por defecto:
+- correo: `admin@admin.com`
+- contrase\u00f1a: `admin`
+
+Ejecuta `npx prisma db seed` para crearlo en la base de datos.

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "devDependencies": {
     "prisma": "5.1.1",
     "typescript": "5.2.2"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.js"
   }
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,29 @@
+const { PrismaClient } = require('@prisma/client')
+const { hash } = require('bcryptjs')
+
+const prisma = new PrismaClient()
+
+async function main() {
+  const email = 'admin@admin.com'
+  const exists = await prisma.user.findUnique({ where: { email } })
+
+  if (!exists) {
+    const password = await hash('admin', 10)
+    await prisma.user.create({
+      data: {
+        name: 'admin',
+        email,
+        password
+      }
+    })
+  }
+}
+
+main()
+  .catch(e => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })


### PR DESCRIPTION
## Summary
- add Prisma seed script that creates default `admin@admin.com` user with password `admin`
- configure `package.json` to run the seed script
- document default credentials in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Missing TypeScript dependencies)

------
https://chatgpt.com/codex/tasks/task_e_689f309bfe148322a4c8f25d7299f158